### PR TITLE
Fork to const-num-traits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.60.0, # MSRV
-          1.62.0, # has_total_cmp
-          1.74.0, # has_num_saturating
+          1.86.0, # MSRV
           stable,
           beta,
           nightly,

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.60.0, stable]
+        rust: [1.86.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.60.0, stable]
+        rust: [1.86.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.86"
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 authors = ["The Rust Project Developers"]
-description = "Numeric traits for generic mathematics"
-documentation = "https://docs.rs/num-traits"
-homepage = "https://github.com/rust-num/num-traits"
+description = "Const-friendly numeric traits for generic mathematics (fork of num-traits)"
+documentation = "https://docs.rs/const-num-traits"
+homepage = "https://github.com/kaidokert/num-traits"
 keywords = ["mathematics", "numerics"]
 categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-num/num-traits"
-name = "num-traits"
-version = "0.2.19"
+repository = "https://github.com/kaidokert/num-traits"
+name = "const-num-traits"
+version = "0.1.0"
 readme = "README.md"
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*"]
@@ -20,12 +20,14 @@ features = ["std"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
+c0nst = "0.2.1"
 libm = { version = "0.2.0", optional = true }
 
 [features]
 default = ["std"]
 libm = ["dep:libm"]
 std = []
+nightly = ["c0nst/nightly"]
 
 # vestigial features, now always in effect
 i128 = []

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -7,44 +7,55 @@ use core::{f32, f64};
 use core::{i128, i16, i32, i64, i8, isize};
 use core::{u128, u16, u32, u64, u8, usize};
 
+c0nst::c0nst! {
 /// Numbers which have upper and lower bounds
-pub trait Bounded {
+pub c0nst trait Bounded {
     // FIXME (#5527): These should be associated constants
     /// Returns the smallest finite number this type can represent
     fn min_value() -> Self;
     /// Returns the largest finite number this type can represent
     fn max_value() -> Self;
 }
+}
 
+c0nst::c0nst! {
 /// Numbers which have lower bounds
-pub trait LowerBounded {
+pub c0nst trait LowerBounded {
     /// Returns the smallest finite number this type can represent
     fn min_value() -> Self;
 }
+}
 
+c0nst::c0nst! {
 // FIXME: With a major version bump, this should be a supertrait instead
-impl<T: Bounded> LowerBounded for T {
+impl<T: [c0nst] Bounded> c0nst LowerBounded for T {
     fn min_value() -> T {
         Bounded::min_value()
     }
 }
+}
 
+c0nst::c0nst! {
 /// Numbers which have upper bounds
-pub trait UpperBounded {
+pub c0nst trait UpperBounded {
     /// Returns the largest finite number this type can represent
     fn max_value() -> Self;
 }
+}
 
+c0nst::c0nst! {
 // FIXME: With a major version bump, this should be a supertrait instead
-impl<T: Bounded> UpperBounded for T {
+impl<T: [c0nst] Bounded> c0nst UpperBounded for T {
     fn max_value() -> T {
         Bounded::max_value()
     }
 }
+}
 
 macro_rules! bounded_impl {
     ($t:ty, $min:expr, $max:expr) => {
-        impl Bounded for $t {
+        c0nst::c0nst! {
+        impl c0nst Bounded for $t {
             #[inline]
             fn min_value() -> $t {
                 $min
@@ -54,6 +65,7 @@ macro_rules! bounded_impl {
             fn max_value() -> $t {
                 $max
             }
+        }
         }
     };
 }
@@ -83,7 +95,8 @@ macro_rules! bounded_impl_nonzero_const {
 
 macro_rules! bounded_impl_nonzero {
     ($t:ty, $min:expr, $max:expr) => {
-        impl Bounded for $t {
+        c0nst::c0nst! {
+        impl c0nst Bounded for $t {
             #[inline]
             fn min_value() -> $t {
                 // when MSRV is 1.70 we can use $t::MIN
@@ -97,6 +110,7 @@ macro_rules! bounded_impl_nonzero {
                 bounded_impl_nonzero_const!($t, $max, MAX);
                 MAX
             }
+        }
         }
     };
 }
@@ -115,13 +129,15 @@ bounded_impl_nonzero!(NonZeroI32, i32::MIN, i32::MAX);
 bounded_impl_nonzero!(NonZeroI64, i64::MIN, i64::MAX);
 bounded_impl_nonzero!(NonZeroI128, i128::MIN, i128::MAX);
 
-impl<T: Bounded> Bounded for Wrapping<T> {
+c0nst::c0nst! {
+impl<T: [c0nst] Bounded> c0nst Bounded for Wrapping<T> {
     fn min_value() -> Self {
         Wrapping(T::min_value())
     }
     fn max_value() -> Self {
         Wrapping(T::max_value())
     }
+}
 }
 
 bounded_impl!(f32, f32::MIN, f32::MAX);
@@ -143,7 +159,8 @@ macro_rules! for_each_tuple {
 
 macro_rules! bounded_tuple {
     ( $($name:ident)* ) => (
-        impl<$($name: Bounded,)*> Bounded for ($($name,)*) {
+        c0nst::c0nst! {
+        impl<$($name: [c0nst] Bounded,)*> c0nst Bounded for ($($name,)*) {
             #[inline]
             fn min_value() -> Self {
                 ($($name::min_value(),)*)
@@ -152,6 +169,7 @@ macro_rules! bounded_tuple {
             fn max_value() -> Self {
                 ($($name::max_value(),)*)
             }
+        }
         }
     );
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -8,6 +8,7 @@ use core::{f32, f64};
 use core::{i128, i16, i32, i64, i8, isize};
 use core::{u128, u16, u32, u64, u8, usize};
 
+c0nst::c0nst! {
 /// A generic trait for converting a value to a number.
 ///
 /// A value can be represented by the target type when it lies within
@@ -18,115 +19,65 @@ use core::{u128, u16, u32, u64, u8, usize};
 /// On the other hand, conversions with possible precision loss or truncation
 /// are admitted, like an `f32` with a decimal part to an integer type, or
 /// even a large `f64` saturating to `f32` infinity.
-pub trait ToPrimitive {
+pub c0nst trait ToPrimitive {
     /// Converts the value of `self` to an `isize`. If the value cannot be
     /// represented by an `isize`, then `None` is returned.
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        self.to_i64().as_ref().and_then(ToPrimitive::to_isize)
-    }
+    fn to_isize(&self) -> Option<isize>;
 
     /// Converts the value of `self` to an `i8`. If the value cannot be
     /// represented by an `i8`, then `None` is returned.
-    #[inline]
-    fn to_i8(&self) -> Option<i8> {
-        self.to_i64().as_ref().and_then(ToPrimitive::to_i8)
-    }
+    fn to_i8(&self) -> Option<i8>;
 
     /// Converts the value of `self` to an `i16`. If the value cannot be
     /// represented by an `i16`, then `None` is returned.
-    #[inline]
-    fn to_i16(&self) -> Option<i16> {
-        self.to_i64().as_ref().and_then(ToPrimitive::to_i16)
-    }
+    fn to_i16(&self) -> Option<i16>;
 
     /// Converts the value of `self` to an `i32`. If the value cannot be
     /// represented by an `i32`, then `None` is returned.
-    #[inline]
-    fn to_i32(&self) -> Option<i32> {
-        self.to_i64().as_ref().and_then(ToPrimitive::to_i32)
-    }
+    fn to_i32(&self) -> Option<i32>;
 
     /// Converts the value of `self` to an `i64`. If the value cannot be
     /// represented by an `i64`, then `None` is returned.
     fn to_i64(&self) -> Option<i64>;
 
     /// Converts the value of `self` to an `i128`. If the value cannot be
-    /// represented by an `i128` (`i64` under the default implementation), then
-    /// `None` is returned.
-    ///
-    /// The default implementation converts through `to_i64()`. Types implementing
-    /// this trait should override this method if they can represent a greater range.
-    #[inline]
-    fn to_i128(&self) -> Option<i128> {
-        self.to_i64().map(From::from)
-    }
+    /// represented by an `i128`, then `None` is returned.
+    fn to_i128(&self) -> Option<i128>;
 
     /// Converts the value of `self` to a `usize`. If the value cannot be
     /// represented by a `usize`, then `None` is returned.
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        self.to_u64().as_ref().and_then(ToPrimitive::to_usize)
-    }
+    fn to_usize(&self) -> Option<usize>;
 
     /// Converts the value of `self` to a `u8`. If the value cannot be
     /// represented by a `u8`, then `None` is returned.
-    #[inline]
-    fn to_u8(&self) -> Option<u8> {
-        self.to_u64().as_ref().and_then(ToPrimitive::to_u8)
-    }
+    fn to_u8(&self) -> Option<u8>;
 
     /// Converts the value of `self` to a `u16`. If the value cannot be
     /// represented by a `u16`, then `None` is returned.
-    #[inline]
-    fn to_u16(&self) -> Option<u16> {
-        self.to_u64().as_ref().and_then(ToPrimitive::to_u16)
-    }
+    fn to_u16(&self) -> Option<u16>;
 
     /// Converts the value of `self` to a `u32`. If the value cannot be
     /// represented by a `u32`, then `None` is returned.
-    #[inline]
-    fn to_u32(&self) -> Option<u32> {
-        self.to_u64().as_ref().and_then(ToPrimitive::to_u32)
-    }
+    fn to_u32(&self) -> Option<u32>;
 
     /// Converts the value of `self` to a `u64`. If the value cannot be
     /// represented by a `u64`, then `None` is returned.
     fn to_u64(&self) -> Option<u64>;
 
     /// Converts the value of `self` to a `u128`. If the value cannot be
-    /// represented by a `u128` (`u64` under the default implementation), then
-    /// `None` is returned.
-    ///
-    /// The default implementation converts through `to_u64()`. Types implementing
-    /// this trait should override this method if they can represent a greater range.
-    #[inline]
-    fn to_u128(&self) -> Option<u128> {
-        self.to_u64().map(From::from)
-    }
+    /// represented by a `u128`, then `None` is returned.
+    fn to_u128(&self) -> Option<u128>;
 
     /// Converts the value of `self` to an `f32`. Overflows may map to positive
     /// or negative inifinity, otherwise `None` is returned if the value cannot
     /// be represented by an `f32`.
-    #[inline]
-    fn to_f32(&self) -> Option<f32> {
-        self.to_f64().as_ref().and_then(ToPrimitive::to_f32)
-    }
+    fn to_f32(&self) -> Option<f32>;
 
     /// Converts the value of `self` to an `f64`. Overflows may map to positive
     /// or negative inifinity, otherwise `None` is returned if the value cannot
     /// be represented by an `f64`.
-    ///
-    /// The default implementation tries to convert through `to_i64()`, and
-    /// failing that through `to_u64()`. Types implementing this trait should
-    /// override this method if they can represent a greater range.
-    #[inline]
-    fn to_f64(&self) -> Option<f64> {
-        match self.to_i64() {
-            Some(i) => i.to_f64(),
-            None => self.to_u64().as_ref().and_then(ToPrimitive::to_f64),
-        }
-    }
+    fn to_f64(&self) -> Option<f64>;
+}
 }
 
 macro_rules! impl_to_primitive_int_to_int {
@@ -160,7 +111,8 @@ macro_rules! impl_to_primitive_int_to_uint {
 
 macro_rules! impl_to_primitive_int {
     ($T:ident) => {
-        impl ToPrimitive for $T {
+        c0nst::c0nst! {
+        impl c0nst ToPrimitive for $T {
             impl_to_primitive_int_to_int! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -187,6 +139,7 @@ macro_rules! impl_to_primitive_int {
             fn to_f64(&self) -> Option<f64> {
                 Some(*self as f64)
             }
+        }
         }
     };
 }
@@ -228,7 +181,8 @@ macro_rules! impl_to_primitive_uint_to_uint {
 
 macro_rules! impl_to_primitive_uint {
     ($T:ident) => {
-        impl ToPrimitive for $T {
+        c0nst::c0nst! {
+        impl c0nst ToPrimitive for $T {
             impl_to_primitive_uint_to_int! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -256,6 +210,7 @@ macro_rules! impl_to_primitive_uint {
                 Some(*self as f64)
             }
         }
+        }
     };
 }
 
@@ -277,7 +232,8 @@ macro_rules! impl_to_primitive_nonzero_to_method {
 
 macro_rules! impl_to_primitive_nonzero {
     ($T:ident) => {
-        impl ToPrimitive for $T {
+        c0nst::c0nst! {
+        impl c0nst ToPrimitive for $T {
             impl_to_primitive_nonzero_to_method! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -296,6 +252,7 @@ macro_rules! impl_to_primitive_nonzero {
                 fn to_f32 -> f32;
                 fn to_f64 -> f64;
             }
+        }
         }
     };
 }
@@ -326,10 +283,11 @@ macro_rules! impl_to_primitive_float_to_float {
 }
 
 macro_rules! float_to_int_unchecked {
-    // SAFETY: Must not be NaN or infinite; must be representable as the integer after truncating.
-    // We already checked that the float is in the exclusive range `(MIN-1, MAX+1)`.
+    // The range check above already guarantees the value is representable.
+    // `to_int_unchecked` would be slightly faster but isn't const yet; the
+    // saturating `as` cast gives the same answer for in-range inputs.
     ($float:expr => $int:ty) => {
-        unsafe { $float.to_int_unchecked::<$int>() }
+        $float as $int
     };
 }
 
@@ -390,7 +348,8 @@ macro_rules! impl_to_primitive_float_to_unsigned_int {
 
 macro_rules! impl_to_primitive_float {
     ($T:ident) => {
-        impl ToPrimitive for $T {
+        c0nst::c0nst! {
+        impl c0nst ToPrimitive for $T {
             impl_to_primitive_float_to_signed_int! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -414,12 +373,14 @@ macro_rules! impl_to_primitive_float {
                 fn to_f64 -> f64;
             }
         }
+        }
     };
 }
 
 impl_to_primitive_float!(f32);
 impl_to_primitive_float!(f64);
 
+c0nst::c0nst! {
 /// A generic trait for converting a number to a value.
 ///
 /// A value can be represented by the target type when it lies within
@@ -430,34 +391,22 @@ impl_to_primitive_float!(f64);
 /// On the other hand, conversions with possible precision loss or truncation
 /// are admitted, like an `f32` with a decimal part to an integer type, or
 /// even a large `f64` saturating to `f32` infinity.
-pub trait FromPrimitive: Sized {
+pub c0nst trait FromPrimitive: Sized {
     /// Converts an `isize` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_isize(n: isize) -> Option<Self> {
-        n.to_i64().and_then(FromPrimitive::from_i64)
-    }
+    fn from_isize(n: isize) -> Option<Self>;
 
     /// Converts an `i8` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_i8(n: i8) -> Option<Self> {
-        FromPrimitive::from_i64(From::from(n))
-    }
+    fn from_i8(n: i8) -> Option<Self>;
 
     /// Converts an `i16` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_i16(n: i16) -> Option<Self> {
-        FromPrimitive::from_i64(From::from(n))
-    }
+    fn from_i16(n: i16) -> Option<Self>;
 
     /// Converts an `i32` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_i32(n: i32) -> Option<Self> {
-        FromPrimitive::from_i64(From::from(n))
-    }
+    fn from_i32(n: i32) -> Option<Self>;
 
     /// Converts an `i64` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
@@ -465,41 +414,23 @@ pub trait FromPrimitive: Sized {
 
     /// Converts an `i128` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    ///
-    /// The default implementation converts through `from_i64()`. Types implementing
-    /// this trait should override this method if they can represent a greater range.
-    #[inline]
-    fn from_i128(n: i128) -> Option<Self> {
-        n.to_i64().and_then(FromPrimitive::from_i64)
-    }
+    fn from_i128(n: i128) -> Option<Self>;
 
     /// Converts a `usize` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_usize(n: usize) -> Option<Self> {
-        n.to_u64().and_then(FromPrimitive::from_u64)
-    }
+    fn from_usize(n: usize) -> Option<Self>;
 
     /// Converts an `u8` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_u8(n: u8) -> Option<Self> {
-        FromPrimitive::from_u64(From::from(n))
-    }
+    fn from_u8(n: u8) -> Option<Self>;
 
     /// Converts an `u16` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_u16(n: u16) -> Option<Self> {
-        FromPrimitive::from_u64(From::from(n))
-    }
+    fn from_u16(n: u16) -> Option<Self>;
 
     /// Converts an `u32` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_u32(n: u32) -> Option<Self> {
-        FromPrimitive::from_u64(From::from(n))
-    }
+    fn from_u32(n: u32) -> Option<Self>;
 
     /// Converts an `u64` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
@@ -507,39 +438,22 @@ pub trait FromPrimitive: Sized {
 
     /// Converts an `u128` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    ///
-    /// The default implementation converts through `from_u64()`. Types implementing
-    /// this trait should override this method if they can represent a greater range.
-    #[inline]
-    fn from_u128(n: u128) -> Option<Self> {
-        n.to_u64().and_then(FromPrimitive::from_u64)
-    }
+    fn from_u128(n: u128) -> Option<Self>;
 
     /// Converts a `f32` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    #[inline]
-    fn from_f32(n: f32) -> Option<Self> {
-        FromPrimitive::from_f64(From::from(n))
-    }
+    fn from_f32(n: f32) -> Option<Self>;
 
     /// Converts a `f64` to return an optional value of this type. If the
     /// value cannot be represented by this type, then `None` is returned.
-    ///
-    /// The default implementation tries to convert through `from_i64()`, and
-    /// failing that through `from_u64()`. Types implementing this trait should
-    /// override this method if they can represent a greater range.
-    #[inline]
-    fn from_f64(n: f64) -> Option<Self> {
-        match n.to_i64() {
-            Some(i) => FromPrimitive::from_i64(i),
-            None => n.to_u64().and_then(FromPrimitive::from_u64),
-        }
-    }
+    fn from_f64(n: f64) -> Option<Self>;
+}
 }
 
 macro_rules! impl_from_primitive {
     ($T:ty, $to_ty:ident) => {
-        impl FromPrimitive for $T {
+        c0nst::c0nst! {
+        impl c0nst FromPrimitive for $T {
             #[inline]
             fn from_isize(n: isize) -> Option<$T> {
                 n.$to_ty()
@@ -598,6 +512,7 @@ macro_rules! impl_from_primitive {
             fn from_f64(n: f64) -> Option<$T> {
                 n.$to_ty()
             }
+        }
         }
     };
 }
@@ -617,67 +532,41 @@ impl_from_primitive!(u128, to_u128);
 impl_from_primitive!(f32, to_f32);
 impl_from_primitive!(f64, to_f64);
 
+// `Option::and_then` is not yet a const fn; written as `match` to stay
+// const-friendly while preserving semantics.
+macro_rules! impl_from_primitive_nonzero_one {
+    ($t:ty, $T:ty, $to_ty:ident, $method:ident) => {
+        #[inline]
+        fn $method(n: $t) -> Option<$T> {
+            match n.$to_ty() {
+                Some(v) => Self::new(v),
+                None => None,
+            }
+        }
+    };
+}
+
 macro_rules! impl_from_primitive_nonzero {
     ($T:ty, $to_ty:ident) => {
-        impl FromPrimitive for $T {
-            #[inline]
-            fn from_isize(n: isize) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_i8(n: i8) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_i16(n: i16) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_i32(n: i32) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_i64(n: i64) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_i128(n: i128) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
+        c0nst::c0nst! {
+        impl c0nst FromPrimitive for $T {
+            impl_from_primitive_nonzero_one!(isize, $T, $to_ty, from_isize);
+            impl_from_primitive_nonzero_one!(i8,    $T, $to_ty, from_i8);
+            impl_from_primitive_nonzero_one!(i16,   $T, $to_ty, from_i16);
+            impl_from_primitive_nonzero_one!(i32,   $T, $to_ty, from_i32);
+            impl_from_primitive_nonzero_one!(i64,   $T, $to_ty, from_i64);
+            impl_from_primitive_nonzero_one!(i128,  $T, $to_ty, from_i128);
 
-            #[inline]
-            fn from_usize(n: usize) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_u8(n: u8) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_u16(n: u16) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_u32(n: u32) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_u64(n: u64) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_u128(n: u128) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
+            impl_from_primitive_nonzero_one!(usize, $T, $to_ty, from_usize);
+            impl_from_primitive_nonzero_one!(u8,    $T, $to_ty, from_u8);
+            impl_from_primitive_nonzero_one!(u16,   $T, $to_ty, from_u16);
+            impl_from_primitive_nonzero_one!(u32,   $T, $to_ty, from_u32);
+            impl_from_primitive_nonzero_one!(u64,   $T, $to_ty, from_u64);
+            impl_from_primitive_nonzero_one!(u128,  $T, $to_ty, from_u128);
 
-            #[inline]
-            fn from_f32(n: f32) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
-            #[inline]
-            fn from_f64(n: f64) -> Option<$T> {
-                n.$to_ty().and_then(Self::new)
-            }
+            impl_from_primitive_nonzero_one!(f32, $T, $to_ty, from_f32);
+            impl_from_primitive_nonzero_one!(f64, $T, $to_ty, from_f64);
+        }
         }
     };
 }
@@ -704,7 +593,8 @@ macro_rules! impl_to_primitive_wrapping {
     )*}
 }
 
-impl<T: ToPrimitive> ToPrimitive for Wrapping<T> {
+c0nst::c0nst! {
+impl<T: [c0nst] ToPrimitive> c0nst ToPrimitive for Wrapping<T> {
     impl_to_primitive_wrapping! {
         fn to_isize -> isize;
         fn to_i8 -> i8;
@@ -724,17 +614,23 @@ impl<T: ToPrimitive> ToPrimitive for Wrapping<T> {
         fn to_f64 -> f64;
     }
 }
+}
 
 macro_rules! impl_from_primitive_wrapping {
     ($( fn $method:ident ( $i:ident ); )*) => {$(
         #[inline]
         fn $method(n: $i) -> Option<Self> {
-            T::$method(n).map(Wrapping)
+            // Hand-rolled match — `Option::map` is not yet a const fn.
+            match T::$method(n) {
+                Some(v) => Some(Wrapping(v)),
+                None => None,
+            }
         }
     )*}
 }
 
-impl<T: FromPrimitive> FromPrimitive for Wrapping<T> {
+c0nst::c0nst! {
+impl<T: [c0nst] FromPrimitive + [c0nst] Destruct> c0nst FromPrimitive for Wrapping<T> {
     impl_from_primitive_wrapping! {
         fn from_isize(isize);
         fn from_i8(i8);
@@ -754,24 +650,28 @@ impl<T: FromPrimitive> FromPrimitive for Wrapping<T> {
         fn from_f64(f64);
     }
 }
+}
 
+c0nst::c0nst! {
 /// Cast from one machine scalar to another.
 ///
 /// # Examples
 ///
 /// ```
-/// # use num_traits as num;
+/// # use const_num_traits as num;
 /// let twenty: f32 = num::cast(0x14).unwrap();
 /// assert_eq!(twenty, 20f32);
 /// ```
 ///
 #[inline]
-pub fn cast<T: NumCast, U: NumCast>(n: T) -> Option<U> {
+pub c0nst fn cast<T: [c0nst] NumCast + [c0nst] Destruct, U: [c0nst] NumCast>(n: T) -> Option<U> {
     NumCast::from(n)
 }
+}
 
+c0nst::c0nst! {
 /// An interface for casting between machine scalars.
-pub trait NumCast: Sized + ToPrimitive {
+pub c0nst trait NumCast: Sized + [c0nst] ToPrimitive {
     /// Creates a number from another value that can be converted into
     /// a primitive via the `ToPrimitive` trait. If the source value cannot be
     /// represented by the target type, then `None` is returned.
@@ -784,16 +684,19 @@ pub trait NumCast: Sized + ToPrimitive {
     /// On the other hand, conversions with possible precision loss or truncation
     /// are admitted, like an `f32` with a decimal part to an integer type, or
     /// even a large `f64` saturating to `f32` infinity.
-    fn from<T: ToPrimitive>(n: T) -> Option<Self>;
+    fn from<T: [c0nst] ToPrimitive + [c0nst] Destruct>(n: T) -> Option<Self>;
+}
 }
 
 macro_rules! impl_num_cast {
     ($T:ty, $conv:ident) => {
-        impl NumCast for $T {
+        c0nst::c0nst! {
+        impl c0nst NumCast for $T {
             #[inline]
-            fn from<N: ToPrimitive>(n: N) -> Option<$T> {
+            fn from<N: [c0nst] ToPrimitive + [c0nst] Destruct>(n: N) -> Option<$T> {
                 n.$conv()
             }
+        }
         }
     };
 }
@@ -815,11 +718,17 @@ impl_num_cast!(f64, to_f64);
 
 macro_rules! impl_num_cast_nonzero {
     ($T:ty, $conv:ident) => {
-        impl NumCast for $T {
+        c0nst::c0nst! {
+        impl c0nst NumCast for $T {
             #[inline]
-            fn from<N: ToPrimitive>(n: N) -> Option<$T> {
-                n.$conv().and_then(Self::new)
+            fn from<N: [c0nst] ToPrimitive + [c0nst] Destruct>(n: N) -> Option<$T> {
+                // `Option::and_then` isn't a const fn yet — hand-roll as match.
+                match n.$conv() {
+                    Some(v) => Self::new(v),
+                    None => None,
+                }
             }
+        }
         }
     };
 }
@@ -838,12 +747,19 @@ impl_num_cast_nonzero!(NonZeroI32, to_i32);
 impl_num_cast_nonzero!(NonZeroI64, to_i64);
 impl_num_cast_nonzero!(NonZeroI128, to_i128);
 
-impl<T: NumCast> NumCast for Wrapping<T> {
-    fn from<U: ToPrimitive>(n: U) -> Option<Self> {
-        T::from(n).map(Wrapping)
+c0nst::c0nst! {
+impl<T: [c0nst] NumCast + [c0nst] Destruct> c0nst NumCast for Wrapping<T> {
+    fn from<U: [c0nst] ToPrimitive + [c0nst] Destruct>(n: U) -> Option<Self> {
+        // Hand-rolled match — `Option::map` is not yet a const fn.
+        match T::from(n) {
+            Some(v) => Some(Wrapping(v)),
+            None => None,
+        }
     }
 }
+}
 
+c0nst::c0nst! {
 /// A generic interface for casting between machine scalars with the
 /// `as` operator, which admits narrowing and precision loss.
 /// Implementers of this trait `AsPrimitive` should behave like a primitive
@@ -853,7 +769,7 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 /// # Examples
 ///
 /// ```
-/// # use num_traits::AsPrimitive;
+/// # use const_num_traits::AsPrimitive;
 /// let three: i32 = (3.14159265f32).as_();
 /// assert_eq!(three, 3);
 /// ```
@@ -866,22 +782,25 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 /// type ([#10184](https://github.com/rust-lang/rust/issues/10184)).
 ///
 /// ```ignore
-/// # use num_traits::AsPrimitive;
+/// # use const_num_traits::AsPrimitive;
 /// let x: u8 = (1.04E+17).as_(); // UB
 /// ```
 ///
-pub trait AsPrimitive<T>: 'static + Copy
+pub c0nst trait AsPrimitive<T>: 'static + Copy
 where
     T: 'static + Copy,
 {
     /// Convert a value to another, using the `as` operator.
     fn as_(self) -> T;
 }
+}
 
 macro_rules! impl_as_primitive {
     (@ $T: ty =>  impl $U: ty ) => {
-        impl AsPrimitive<$U> for $T {
+        c0nst::c0nst! {
+        impl c0nst AsPrimitive<$U> for $T {
             #[inline] fn as_(self) -> $U { self as $U }
+        }
         }
     };
     (@ $T: ty => { $( $U: ty ),* } ) => {$(

--- a/src/float.rs
+++ b/src/float.rs
@@ -16,7 +16,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -33,7 +33,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -50,7 +50,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     ///
     /// fn check<T: FloatCore>() {
     ///     let n = T::nan();
@@ -67,7 +67,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(n: T) {
@@ -86,7 +86,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -103,7 +103,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -120,7 +120,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -137,7 +137,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T) {
@@ -154,7 +154,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -177,7 +177,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -201,7 +201,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -224,7 +224,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -245,7 +245,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// Returns `true` if the number is [subnormal].
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::f64;
     ///
     /// let min = f64::MIN_POSITIVE; // 2.2250738585072014e-308_f64
@@ -275,7 +275,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     /// use std::num::FpCategory;
     ///
@@ -297,7 +297,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -331,7 +331,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -365,7 +365,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -406,7 +406,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -438,7 +438,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -470,7 +470,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -504,7 +504,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -535,7 +535,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -562,7 +562,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, p: bool) {
@@ -591,7 +591,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T, min: T) {
@@ -625,7 +625,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T, max: T) {
@@ -663,7 +663,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     ///
     /// fn check<T: FloatCore>(val: T, min: T, max: T, expected: T) {
     ///     assert!(val.clamp(min, max) == expected);
@@ -687,7 +687,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, y: T) {
@@ -712,7 +712,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     ///
     /// fn check<T: FloatCore>(x: T, exp: i32, powi: T) {
     ///     assert!(x.powi(exp) == powi);
@@ -741,7 +741,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(rad: T, deg: T) {
@@ -760,7 +760,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(deg: T, rad: T) {
@@ -780,7 +780,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::float::FloatCore;
+    /// use const_num_traits::float::FloatCore;
     /// use std::{f32, f64};
     ///
     /// fn check<T: FloatCore>(x: T, m: u64, e: i16, s:i8) {
@@ -933,7 +933,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the `NaN` value.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let nan: f32 = Float::nan();
     ///
@@ -943,7 +943,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the infinite value.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f32;
     ///
     /// let infinity: f32 = Float::infinity();
@@ -956,7 +956,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the negative infinite value.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f32;
     ///
     /// let neg_infinity: f32 = Float::neg_infinity();
@@ -969,7 +969,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `-0.0`.
     ///
     /// ```
-    /// use num_traits::{Zero, Float};
+    /// use const_num_traits::{Zero, Float};
     ///
     /// let inf: f32 = Float::infinity();
     /// let zero: f32 = Zero::zero();
@@ -984,7 +984,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x: f64 = Float::min_value();
@@ -996,7 +996,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x: f64 = Float::min_positive_value();
@@ -1008,7 +1008,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns epsilon, a small positive value.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x: f64 = Float::epsilon();
@@ -1027,7 +1027,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x: f64 = Float::max_value();
@@ -1038,7 +1038,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if this value is `NaN` and false otherwise.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let nan = f64::NAN;
@@ -1053,7 +1053,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// false otherwise.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f32;
     ///
     /// let f = 7.0f32;
@@ -1072,7 +1072,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if this number is neither infinite nor `NaN`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f32;
     ///
     /// let f = 7.0f32;
@@ -1092,7 +1092,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// [subnormal][subnormal], or `NaN`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f32;
     ///
     /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f32
@@ -1115,7 +1115,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if the number is [subnormal].
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let min = f64::MIN_POSITIVE; // 2.2250738585072014e-308_f64
@@ -1143,7 +1143,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// predicate instead.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::num::FpCategory;
     /// use std::f32;
     ///
@@ -1158,7 +1158,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 3.99;
     /// let g = 3.0;
@@ -1171,7 +1171,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 3.01;
     /// let g = 4.0;
@@ -1185,7 +1185,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `0.0`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 3.3;
     /// let g = -3.3;
@@ -1198,7 +1198,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 3.3;
     /// let g = -3.7;
@@ -1211,7 +1211,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 3.5;
     /// let y = -3.5;
@@ -1227,7 +1227,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is `Float::nan()`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = 3.5;
@@ -1250,7 +1250,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let f = 3.5;
@@ -1266,7 +1266,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::infinity()`, and `Float::nan()`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
@@ -1286,7 +1286,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::neg_infinity()`, and `-Float::nan()`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
@@ -1309,7 +1309,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let m = 10.0;
     /// let x = 4.0;
@@ -1324,7 +1324,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
@@ -1338,7 +1338,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
@@ -1350,7 +1350,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Raise a number to a floating point power.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
@@ -1364,7 +1364,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns NaN if `self` is a negative number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let positive = 4.0;
     /// let negative = -4.0;
@@ -1379,7 +1379,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -1395,7 +1395,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 2.0;
     ///
@@ -1409,7 +1409,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the natural logarithm of the number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -1425,7 +1425,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the logarithm of the number with respect to an arbitrary base.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let ten = 10.0;
     /// let two = 2.0;
@@ -1444,7 +1444,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the base 2 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let two = 2.0;
     ///
@@ -1458,7 +1458,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the base 10 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let ten = 10.0;
     ///
@@ -1508,7 +1508,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -1520,7 +1520,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -1534,7 +1534,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// **Panics** in debug mode if `!(min <= max)`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -1552,7 +1552,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * Else: `self - other`
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 3.0;
     /// let y = -3.0;
@@ -1568,7 +1568,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Take the cubic root of a number.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 8.0;
     ///
@@ -1583,7 +1583,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 2.0;
     /// let y = 3.0;
@@ -1598,7 +1598,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/2.0;
@@ -1612,7 +1612,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = 2.0*f64::consts::PI;
@@ -1626,7 +1626,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -1641,7 +1641,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 2.0;
@@ -1658,7 +1658,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 4.0;
@@ -1674,7 +1674,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 1.0;
     ///
@@ -1693,7 +1693,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let pi = f64::consts::PI;
@@ -1718,7 +1718,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -1736,7 +1736,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is close to zero.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 7.0;
     ///
@@ -1751,7 +1751,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// the operations were performed separately.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::E - 1.0;
@@ -1766,7 +1766,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -1784,7 +1784,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -1802,7 +1802,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -1820,7 +1820,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 1.0;
     /// let f = x.sinh().asinh();
@@ -1834,7 +1834,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let x = 1.0;
     /// let f = x.cosh().acosh();
@@ -1848,7 +1848,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -1864,7 +1864,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// The original number can be recovered by `sign * mantissa * 2 ^ exponent`.
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let num = 42_f32;
     ///
@@ -1891,7 +1891,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::Float;
+    /// use const_num_traits::Float;
     ///
     /// let f = 3.5_f32;
     ///
@@ -2277,7 +2277,7 @@ pub trait TotalOrder {
     ///
     /// # Examples
     /// ```
-    /// use num_traits::float::TotalOrder;
+    /// use const_num_traits::float::TotalOrder;
     /// use std::cmp::Ordering;
     /// use std::{f32, f64};
     ///

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -4,6 +4,7 @@ use core::ops::{Add, Mul};
 #[cfg(has_num_saturating)]
 use core::num::Saturating;
 
+c0nst::c0nst! {
 /// Defines an additive identity element for `Self`.
 ///
 /// # Laws
@@ -12,7 +13,7 @@ use core::num::Saturating;
 /// a + 0 = a       ∀ a ∈ Self
 /// 0 + a = a       ∀ a ∈ Self
 /// ```
-pub trait Zero: Sized + Add<Self, Output = Self> {
+pub c0nst trait Zero: Sized + [c0nst] Add<Self, Output = Self> {
     /// Returns the additive identity element of `Self`, `0`.
     /// # Purity
     ///
@@ -23,12 +24,11 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn zero() -> Self;
 
     /// Sets `self` to the additive identity element of `Self`, `0`.
-    fn set_zero(&mut self) {
-        *self = Zero::zero();
-    }
+    fn set_zero(&mut self);
 
     /// Returns `true` if `self` is equal to the additive identity.
     fn is_zero(&self) -> bool;
+}
 }
 
 /// Defines an associated constant representing the additive identity element
@@ -40,15 +40,21 @@ pub trait ConstZero: Zero {
 
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
-        impl Zero for $t {
+        c0nst::c0nst! {
+        impl c0nst Zero for $t {
             #[inline]
             fn zero() -> $t {
                 $v
             }
             #[inline]
+            fn set_zero(&mut self) {
+                *self = $v;
+            }
+            #[inline]
             fn is_zero(&self) -> bool {
                 *self == $v
             }
+        }
         }
 
         impl ConstZero for $t {
@@ -74,9 +80,10 @@ zero_impl!(i128, 0);
 zero_impl!(f32, 0.0);
 zero_impl!(f64, 0.0);
 
-impl<T: Zero> Zero for Wrapping<T>
+c0nst::c0nst! {
+impl<T: [c0nst] Zero> c0nst Zero for Wrapping<T>
 where
-    Wrapping<T>: Add<Output = Wrapping<T>>,
+    Wrapping<T>: [c0nst] Add<Output = Wrapping<T>>,
 {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
@@ -90,6 +97,7 @@ where
         Wrapping(T::zero())
     }
 }
+}
 
 impl<T: ConstZero> ConstZero for Wrapping<T>
 where
@@ -99,9 +107,10 @@ where
 }
 
 #[cfg(has_num_saturating)]
-impl<T: Zero> Zero for Saturating<T>
+c0nst::c0nst! {
+impl<T: [c0nst] Zero> c0nst Zero for Saturating<T>
 where
-    Saturating<T>: Add<Output = Saturating<T>>,
+    Saturating<T>: [c0nst] Add<Output = Saturating<T>>,
 {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
@@ -115,6 +124,7 @@ where
         Saturating(T::zero())
     }
 }
+}
 
 #[cfg(has_num_saturating)]
 impl<T: ConstZero> ConstZero for Saturating<T>
@@ -124,6 +134,7 @@ where
     const ZERO: Self = Saturating(T::ZERO);
 }
 
+c0nst::c0nst! {
 /// Defines a multiplicative identity element for `Self`.
 ///
 /// # Laws
@@ -132,7 +143,7 @@ where
 /// a * 1 = a       ∀ a ∈ Self
 /// 1 * a = a       ∀ a ∈ Self
 /// ```
-pub trait One: Sized + Mul<Self, Output = Self> {
+pub c0nst trait One: Sized + [c0nst] Mul<Self, Output = Self> {
     /// Returns the multiplicative identity element of `Self`, `1`.
     ///
     /// # Purity
@@ -144,22 +155,11 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     fn one() -> Self;
 
     /// Sets `self` to the multiplicative identity element of `Self`, `1`.
-    fn set_one(&mut self) {
-        *self = One::one();
-    }
+    fn set_one(&mut self);
 
     /// Returns `true` if `self` is equal to the multiplicative identity.
-    ///
-    /// For performance reasons, it's best to implement this manually.
-    /// After a semver bump, this method will be required, and the
-    /// `where Self: PartialEq` bound will be removed.
-    #[inline]
-    fn is_one(&self) -> bool
-    where
-        Self: PartialEq,
-    {
-        *self == Self::one()
-    }
+    fn is_one(&self) -> bool;
+}
 }
 
 /// Defines an associated constant representing the multiplicative identity
@@ -171,15 +171,21 @@ pub trait ConstOne: One {
 
 macro_rules! one_impl {
     ($t:ty, $v:expr) => {
-        impl One for $t {
+        c0nst::c0nst! {
+        impl c0nst One for $t {
             #[inline]
             fn one() -> $t {
                 $v
             }
             #[inline]
+            fn set_one(&mut self) {
+                *self = $v;
+            }
+            #[inline]
             fn is_one(&self) -> bool {
                 *self == $v
             }
+        }
         }
 
         impl ConstOne for $t {
@@ -205,9 +211,10 @@ one_impl!(i128, 1);
 one_impl!(f32, 1.0);
 one_impl!(f64, 1.0);
 
-impl<T: One> One for Wrapping<T>
+c0nst::c0nst! {
+impl<T: [c0nst] One> c0nst One for Wrapping<T>
 where
-    Wrapping<T>: Mul<Output = Wrapping<T>>,
+    Wrapping<T>: [c0nst] Mul<Output = Wrapping<T>>,
 {
     fn set_one(&mut self) {
         self.0.set_one();
@@ -216,6 +223,11 @@ where
     fn one() -> Self {
         Wrapping(T::one())
     }
+
+    fn is_one(&self) -> bool {
+        self.0.is_one()
+    }
+}
 }
 
 impl<T: ConstOne> ConstOne for Wrapping<T>
@@ -226,9 +238,10 @@ where
 }
 
 #[cfg(has_num_saturating)]
-impl<T: One> One for Saturating<T>
+c0nst::c0nst! {
+impl<T: [c0nst] One> c0nst One for Saturating<T>
 where
-    Saturating<T>: Mul<Output = Saturating<T>>,
+    Saturating<T>: [c0nst] Mul<Output = Saturating<T>>,
 {
     fn set_one(&mut self) {
         self.0.set_one();
@@ -237,6 +250,11 @@ where
     fn one() -> Self {
         Saturating(T::one())
     }
+
+    fn is_one(&self) -> bool {
+        self.0.is_one()
+    }
+}
 }
 
 #[cfg(has_num_saturating)]
@@ -249,16 +267,20 @@ where
 
 // Some helper functions provided for backwards compatibility.
 
+c0nst::c0nst! {
 /// Returns the additive identity, `0`.
 #[inline(always)]
-pub fn zero<T: Zero>() -> T {
+pub c0nst fn zero<T: [c0nst] Zero>() -> T {
     Zero::zero()
 }
+}
 
+c0nst::c0nst! {
 /// Returns the multiplicative identity, `1`.
 #[inline(always)]
-pub fn one<T: One>() -> T {
+pub c0nst fn one<T: [c0nst] One>() -> T {
     One::one()
+}
 }
 
 #[test]

--- a/src/int.rs
+++ b/src/int.rs
@@ -5,6 +5,7 @@ use crate::ops::checked::*;
 use crate::ops::saturating::Saturating;
 use crate::{Num, NumCast};
 
+c0nst::c0nst! {
 /// Generic trait for primitive integers.
 ///
 /// The `PrimInt` trait is an abstraction over the builtin primitive integer types (e.g., `u8`,
@@ -31,33 +32,33 @@ use crate::{Num, NumCast};
 /// This trait and many of the method names originate in the unstable `core::num::Int` trait from
 /// the rust standard library. The original trait was never stabilized and thus removed from the
 /// standard library.
-pub trait PrimInt:
+pub c0nst trait PrimInt:
     Sized
     + Copy
-    + Num
-    + NumCast
-    + Bounded
-    + PartialOrd
-    + Ord
-    + Eq
-    + Not<Output = Self>
-    + BitAnd<Output = Self>
-    + BitOr<Output = Self>
-    + BitXor<Output = Self>
-    + Shl<usize, Output = Self>
-    + Shr<usize, Output = Self>
-    + CheckedAdd<Output = Self>
-    + CheckedSub<Output = Self>
-    + CheckedMul<Output = Self>
-    + CheckedDiv<Output = Self>
-    + Saturating
+    + [c0nst] Num
+    + [c0nst] NumCast
+    + [c0nst] Bounded
+    + [c0nst] PartialOrd
+    + [c0nst] Ord
+    + [c0nst] Eq
+    + [c0nst] Not<Output = Self>
+    + [c0nst] BitAnd<Output = Self>
+    + [c0nst] BitOr<Output = Self>
+    + [c0nst] BitXor<Output = Self>
+    + [c0nst] Shl<usize, Output = Self>
+    + [c0nst] Shr<usize, Output = Self>
+    + [c0nst] CheckedAdd<Output = Self>
+    + [c0nst] CheckedSub<Output = Self>
+    + [c0nst] CheckedMul<Output = Self>
+    + [c0nst] CheckedDiv<Output = Self>
+    + [c0nst] Saturating
 {
     /// Returns the number of ones in the binary representation of `self`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0b01001100u8;
     ///
@@ -70,7 +71,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0b01001100u8;
     ///
@@ -84,7 +85,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0xF00Du16;
     ///
@@ -100,7 +101,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0b0101000u16;
     ///
@@ -114,7 +115,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0xBEEFu16;
     ///
@@ -130,7 +131,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0b0101000u16;
     ///
@@ -144,7 +145,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     /// let m = 0x3456789ABCDEF012u64;
@@ -159,7 +160,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     /// let m = 0xDEF0123456789ABCu64;
@@ -176,7 +177,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     /// let m = 0x3456789ABCDEF000u64;
@@ -193,7 +194,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0xFEDCBA9876543210u64;
     /// let m = 0xFFFFEDCBA9876543u64;
@@ -210,7 +211,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFi64;
     /// let m = 0x3456789ABCDEF000i64;
@@ -227,7 +228,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = -8i8; // 0b11111000
     /// let m = 62i8; // 0b00111110
@@ -241,7 +242,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     /// let m = 0xEFCDAB8967452301u64;
@@ -258,7 +259,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x12345678u32;
     /// let m = 0x1e6a2c48u32;
@@ -277,7 +278,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     ///
@@ -296,7 +297,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     ///
@@ -315,7 +316,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     ///
@@ -334,7 +335,7 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// let n = 0x0123456789ABCDEFu64;
     ///
@@ -351,14 +352,16 @@ pub trait PrimInt:
     /// # Examples
     ///
     /// ```
-    /// use num_traits::PrimInt;
+    /// use const_num_traits::PrimInt;
     ///
     /// assert_eq!(2i32.pow(4), 16);
     /// ```
     fn pow(self, exp: u32) -> Self;
 }
+}
 
-fn one_per_byte<P: PrimInt>() -> P {
+c0nst::c0nst! {
+c0nst fn one_per_byte<P: [c0nst] PrimInt>() -> P {
     // i8, u8: return 0x01
     // i16, u16: return 0x0101 = (0x01 << 8) | 0x01
     // i32, u32: return 0x01010101 = (0x0101 << 16) | 0x0101
@@ -373,8 +376,10 @@ fn one_per_byte<P: PrimInt>() -> P {
     }
     ret
 }
+}
 
-fn reverse_bits_fallback<P: PrimInt>(i: P) -> P {
+c0nst::c0nst! {
+c0nst fn reverse_bits_fallback<P: [c0nst] PrimInt>(i: P) -> P {
     let rep_01: P = one_per_byte();
     let rep_03 = (rep_01 << 1) | rep_01;
     let rep_05 = (rep_01 << 2) | rep_01;
@@ -390,10 +395,12 @@ fn reverse_bits_fallback<P: PrimInt>(i: P) -> P {
     ret = ((ret & rep_55) << 1) | ((ret >> 1) & rep_55);
     ret
 }
+}
 
 macro_rules! prim_int_impl {
     ($T:ty, $S:ty, $U:ty) => {
-        impl PrimInt for $T {
+        c0nst::c0nst! {
+        impl c0nst PrimInt for $T {
             #[inline]
             fn count_ones(self) -> u32 {
                 <$T>::count_ones(self)
@@ -488,6 +495,7 @@ macro_rules! prim_int_impl {
             fn pow(self, exp: u32) -> Self {
                 <$T>::pow(self, exp)
             }
+        }
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Compatibility
 //!
-//! The `const-num-traits` crate is tested for rustc 1.60 and greater.
+//! The `const-num-traits` crate is tested for rustc 1.86 and greater.
 
 #![doc(html_root_url = "https://docs.rs/const-num-traits/0.1")]
 #![deny(unconditional_recursion)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,15 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-traits` crate is tested for rustc 1.60 and greater.
+//! The `const-num-traits` crate is tested for rustc 1.60 and greater.
 
-#![doc(html_root_url = "https://docs.rs/num-traits/0.2")]
+#![doc(html_root_url = "https://docs.rs/const-num-traits/0.1")]
 #![deny(unconditional_recursion)]
 #![no_std]
+#![cfg_attr(
+    feature = "nightly",
+    feature(const_trait_impl, const_ops, const_cmp, const_destruct)
+)]
 
 // Need to explicitly bring the crate in for inherent float methods
 #[cfg(feature = "std")]
@@ -31,7 +35,7 @@ pub use crate::bounds::Bounded;
 #[cfg(any(feature = "std", feature = "libm"))]
 pub use crate::float::Float;
 pub use crate::float::FloatConst;
-// pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
+// pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use const_num_traits::*;`.
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, ConstOne, ConstZero, One, Zero};
 pub use crate::int::PrimInt;
@@ -62,9 +66,10 @@ pub mod pow;
 pub mod real;
 pub mod sign;
 
+c0nst::c0nst! {
 /// The base trait for numeric types, covering `0` and `1` values,
 /// comparisons, basic numeric operations, and string conversion.
-pub trait Num: PartialEq + Zero + One + NumOps {
+pub c0nst trait Num: [c0nst] PartialEq + [c0nst] Zero + [c0nst] One + [c0nst] NumOps {
     type FromStrRadixErr;
 
     /// Convert from a string and radix (typically `2..=36`).
@@ -72,7 +77,7 @@ pub trait Num: PartialEq + Zero + One + NumOps {
     /// # Examples
     ///
     /// ```rust
-    /// use num_traits::Num;
+    /// use const_num_traits::Num;
     ///
     /// let result = <i32 as Num>::from_str_radix("27", 10);
     /// assert_eq!(result, Ok(27));
@@ -94,73 +99,99 @@ pub trait Num: PartialEq + Zero + One + NumOps {
     /// parsing doesn't make sense for that type.
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr>;
 }
+}
 
+c0nst::c0nst! {
 /// Generic trait for types implementing basic numeric operations
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait NumOps<Rhs = Self, Output = Self>:
-    Add<Rhs, Output = Output>
-    + Sub<Rhs, Output = Output>
-    + Mul<Rhs, Output = Output>
-    + Div<Rhs, Output = Output>
-    + Rem<Rhs, Output = Output>
+pub c0nst trait NumOps<Rhs = Self, Output = Self>:
+    [c0nst] Add<Rhs, Output = Output>
+    + [c0nst] Sub<Rhs, Output = Output>
+    + [c0nst] Mul<Rhs, Output = Output>
+    + [c0nst] Div<Rhs, Output = Output>
+    + [c0nst] Rem<Rhs, Output = Output>
 {
 }
-
-impl<T, Rhs, Output> NumOps<Rhs, Output> for T where
-    T: Add<Rhs, Output = Output>
-        + Sub<Rhs, Output = Output>
-        + Mul<Rhs, Output = Output>
-        + Div<Rhs, Output = Output>
-        + Rem<Rhs, Output = Output>
-{
 }
 
+c0nst::c0nst! {
+impl<T, Rhs, Output> c0nst NumOps<Rhs, Output> for T where
+    T: [c0nst] Add<Rhs, Output = Output>
+        + [c0nst] Sub<Rhs, Output = Output>
+        + [c0nst] Mul<Rhs, Output = Output>
+        + [c0nst] Div<Rhs, Output = Output>
+        + [c0nst] Rem<Rhs, Output = Output>
+{
+}
+}
+
+c0nst::c0nst! {
 /// The trait for `Num` types which also implement numeric operations taking
 /// the second operand by reference.
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait NumRef: Num + for<'r> NumOps<&'r Self> {}
-impl<T> NumRef for T where T: Num + for<'r> NumOps<&'r T> {}
+pub c0nst trait NumRef: [c0nst] Num + for<'r> [c0nst] NumOps<&'r Self> {}
+}
+c0nst::c0nst! {
+impl<T> c0nst NumRef for T where T: [c0nst] Num + for<'r> [c0nst] NumOps<&'r T> {}
+}
 
+c0nst::c0nst! {
 /// The trait for `Num` references which implement numeric operations, taking the
 /// second operand either by value or by reference.
 ///
 /// This is automatically implemented for all types which implement the operators. It covers
 /// every type implementing the operations though, regardless of it being a reference or
 /// related to `Num`.
-pub trait RefNum<Base>: NumOps<Base, Base> + for<'r> NumOps<&'r Base, Base> {}
-impl<T, Base> RefNum<Base> for T where T: NumOps<Base, Base> + for<'r> NumOps<&'r Base, Base> {}
+pub c0nst trait RefNum<Base>: [c0nst] NumOps<Base, Base> + for<'r> [c0nst] NumOps<&'r Base, Base> {}
+}
+c0nst::c0nst! {
+impl<T, Base> c0nst RefNum<Base> for T where T: [c0nst] NumOps<Base, Base> + for<'r> [c0nst] NumOps<&'r Base, Base> {}
+}
 
+c0nst::c0nst! {
 /// Generic trait for types implementing numeric assignment operators (like `+=`).
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait NumAssignOps<Rhs = Self>:
-    AddAssign<Rhs> + SubAssign<Rhs> + MulAssign<Rhs> + DivAssign<Rhs> + RemAssign<Rhs>
+pub c0nst trait NumAssignOps<Rhs = Self>:
+    [c0nst] AddAssign<Rhs> + [c0nst] SubAssign<Rhs> + [c0nst] MulAssign<Rhs> + [c0nst] DivAssign<Rhs> + [c0nst] RemAssign<Rhs>
 {
 }
-
-impl<T, Rhs> NumAssignOps<Rhs> for T where
-    T: AddAssign<Rhs> + SubAssign<Rhs> + MulAssign<Rhs> + DivAssign<Rhs> + RemAssign<Rhs>
-{
 }
 
+c0nst::c0nst! {
+impl<T, Rhs> c0nst NumAssignOps<Rhs> for T where
+    T: [c0nst] AddAssign<Rhs> + [c0nst] SubAssign<Rhs> + [c0nst] MulAssign<Rhs> + [c0nst] DivAssign<Rhs> + [c0nst] RemAssign<Rhs>
+{
+}
+}
+
+c0nst::c0nst! {
 /// The trait for `Num` types which also implement assignment operators.
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait NumAssign: Num + NumAssignOps {}
-impl<T> NumAssign for T where T: Num + NumAssignOps {}
+pub c0nst trait NumAssign: [c0nst] Num + [c0nst] NumAssignOps {}
+}
+c0nst::c0nst! {
+impl<T> c0nst NumAssign for T where T: [c0nst] Num + [c0nst] NumAssignOps {}
+}
 
+c0nst::c0nst! {
 /// The trait for `NumAssign` types which also implement assignment operations
 /// taking the second operand by reference.
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait NumAssignRef: NumAssign + for<'r> NumAssignOps<&'r Self> {}
-impl<T> NumAssignRef for T where T: NumAssign + for<'r> NumAssignOps<&'r T> {}
+pub c0nst trait NumAssignRef: [c0nst] NumAssign + for<'r> [c0nst] NumAssignOps<&'r Self> {}
+}
+c0nst::c0nst! {
+impl<T> c0nst NumAssignRef for T where T: [c0nst] NumAssign + for<'r> [c0nst] NumAssignOps<&'r T> {}
+}
 
 macro_rules! int_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
-        impl $name for $t {
+        c0nst::c0nst! {
+        impl c0nst $name for $t {
             type FromStrRadixErr = ::core::num::ParseIntError;
             #[inline]
             fn from_str_radix(s: &str, radix: u32)
@@ -169,11 +200,14 @@ macro_rules! int_trait_impl {
                 <$t>::from_str_radix(s, radix)
             }
         }
+        }
     )*)
 }
 int_trait_impl!(Num for usize u8 u16 u32 u64 u128);
 int_trait_impl!(Num for isize i8 i16 i32 i64 i128);
 
+// Wrapping<T>'s `PartialEq` impl in std isn't const yet, so this stays a
+// non-const impl of the (otherwise const) `Num` trait.
 impl<T: Num> Num for Wrapping<T>
 where
     Wrapping<T>: NumOps,
@@ -184,6 +218,7 @@ where
     }
 }
 
+// Same caveat as Wrapping<T>: no const PartialEq impl in std.
 #[cfg(has_num_saturating)]
 impl<T: Num> Num for core::num::Saturating<T>
 where
@@ -229,6 +264,9 @@ fn str_to_ascii_lower_eq_str(a: &str, b: &str) -> bool {
 // FIXME: The standard library from_str_radix on floats was deprecated, so we're stuck
 // with this implementation ourselves until we want to make a breaking change.
 // (would have to drop it from `Num` though)
+//
+// Non-const impl of the const `Num` trait: this parser uses iterators,
+// `Result::map_err`, `?`, and `str::parse`, none of which are const.
 macro_rules! float_trait_impl {
     ($name:ident for $($t:ident)*) => ($(
         impl $name for $t {
@@ -402,6 +440,7 @@ macro_rules! float_trait_impl {
 }
 float_trait_impl!(Num for f32 f64);
 
+c0nst::c0nst! {
 /// A value bounded by a minimum and a maximum
 ///
 ///  If input is less than min then this returns min.
@@ -410,7 +449,7 @@ float_trait_impl!(Num for f32 f64);
 ///
 /// **Panics** in debug mode if `!(min <= max)`.
 #[inline]
-pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
+pub c0nst fn clamp<T: [c0nst] PartialOrd + [c0nst] Destruct>(input: T, min: T, max: T) -> T {
     debug_assert!(min <= max, "min must be less than or equal to max");
     if input < min {
         min
@@ -420,7 +459,9 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
         input
     }
 }
+}
 
+c0nst::c0nst! {
 /// A value bounded by a minimum value
 ///
 ///  If input is less than min then this returns min.
@@ -430,7 +471,7 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
 /// **Panics** in debug mode if `!(min == min)`. (This occurs if `min` is `NAN`.)
 #[inline]
 #[allow(clippy::eq_op)]
-pub fn clamp_min<T: PartialOrd>(input: T, min: T) -> T {
+pub c0nst fn clamp_min<T: [c0nst] PartialOrd + [c0nst] Destruct>(input: T, min: T) -> T {
     debug_assert!(min == min, "min must not be NAN");
     if input < min {
         min
@@ -438,7 +479,9 @@ pub fn clamp_min<T: PartialOrd>(input: T, min: T) -> T {
         input
     }
 }
+}
 
+c0nst::c0nst! {
 /// A value bounded by a maximum value
 ///
 ///  If input is greater than max then this returns max.
@@ -448,13 +491,14 @@ pub fn clamp_min<T: PartialOrd>(input: T, min: T) -> T {
 /// **Panics** in debug mode if `!(max == max)`. (This occurs if `max` is `NAN`.)
 #[inline]
 #[allow(clippy::eq_op)]
-pub fn clamp_max<T: PartialOrd>(input: T, max: T) -> T {
+pub c0nst fn clamp_max<T: [c0nst] PartialOrd + [c0nst] Destruct>(input: T, max: T) -> T {
     debug_assert!(max == max, "max must not be NAN");
     if input > max {
         max
     } else {
         input
     }
+}
 }
 
 #[test]

--- a/src/ops/bytes.rs
+++ b/src/ops/bytes.rs
@@ -3,7 +3,8 @@ use core::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use core::fmt::Debug;
 use core::hash::Hash;
 
-pub trait NumBytes:
+c0nst::c0nst! {
+pub c0nst trait NumBytes:
     Debug
     + AsRef<[u8]>
     + AsMut<[u8]>
@@ -16,8 +17,10 @@ pub trait NumBytes:
     + BorrowMut<[u8]>
 {
 }
+}
 
-impl<T> NumBytes for T where
+c0nst::c0nst! {
+impl<T> c0nst NumBytes for T where
     T: Debug
         + AsRef<[u8]>
         + AsMut<[u8]>
@@ -31,8 +34,10 @@ impl<T> NumBytes for T where
         + ?Sized
 {
 }
+}
 
-pub trait ToBytes {
+c0nst::c0nst! {
+pub c0nst trait ToBytes {
     type Bytes: NumBytes;
 
     /// Return the memory representation of this number as a byte array in big-endian byte order.
@@ -40,7 +45,7 @@ pub trait ToBytes {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::ToBytes;
+    /// use const_num_traits::ToBytes;
     ///
     /// let bytes = ToBytes::to_be_bytes(&0x12345678u32);
     /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
@@ -52,7 +57,7 @@ pub trait ToBytes {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::ToBytes;
+    /// use const_num_traits::ToBytes;
     ///
     /// let bytes = ToBytes::to_le_bytes(&0x12345678u32);
     /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
@@ -70,7 +75,7 @@ pub trait ToBytes {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::ToBytes;
+    /// use const_num_traits::ToBytes;
     ///
     /// #[cfg(target_endian = "big")]
     /// let expected = [0x12, 0x34, 0x56, 0x78];
@@ -89,8 +94,10 @@ pub trait ToBytes {
         bytes
     }
 }
+}
 
-pub trait FromBytes: Sized {
+c0nst::c0nst! {
+pub c0nst trait FromBytes: Sized {
     type Bytes: NumBytes + ?Sized;
 
     /// Create a number from its representation as a byte array in big endian.
@@ -98,7 +105,7 @@ pub trait FromBytes: Sized {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::FromBytes;
+    /// use const_num_traits::FromBytes;
     ///
     /// let value: u32 = FromBytes::from_be_bytes(&[0x12, 0x34, 0x56, 0x78]);
     /// assert_eq!(value, 0x12345678);
@@ -110,7 +117,7 @@ pub trait FromBytes: Sized {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::FromBytes;
+    /// use const_num_traits::FromBytes;
     ///
     /// let value: u32 = FromBytes::from_le_bytes(&[0x78, 0x56, 0x34, 0x12]);
     /// assert_eq!(value, 0x12345678);
@@ -128,7 +135,7 @@ pub trait FromBytes: Sized {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::FromBytes;
+    /// use const_num_traits::FromBytes;
     ///
     /// #[cfg(target_endian = "big")]
     /// let bytes = [0x12, 0x34, 0x56, 0x78];
@@ -147,10 +154,12 @@ pub trait FromBytes: Sized {
         this
     }
 }
+}
 
 macro_rules! float_to_from_bytes_impl {
     ($T:ty, $L:expr) => {
-        impl ToBytes for $T {
+        c0nst::c0nst! {
+        impl c0nst ToBytes for $T {
             type Bytes = [u8; $L];
 
             #[inline]
@@ -168,8 +177,10 @@ macro_rules! float_to_from_bytes_impl {
                 <$T>::to_ne_bytes(*self)
             }
         }
+        }
 
-        impl FromBytes for $T {
+        c0nst::c0nst! {
+        impl c0nst FromBytes for $T {
             type Bytes = [u8; $L];
 
             #[inline]
@@ -186,13 +197,15 @@ macro_rules! float_to_from_bytes_impl {
             fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
                 <$T>::from_ne_bytes(*bytes)
             }
+        }
         }
     };
 }
 
 macro_rules! int_to_from_bytes_impl {
     ($T:ty, $L:expr) => {
-        impl ToBytes for $T {
+        c0nst::c0nst! {
+        impl c0nst ToBytes for $T {
             type Bytes = [u8; $L];
 
             #[inline]
@@ -210,8 +223,10 @@ macro_rules! int_to_from_bytes_impl {
                 <$T>::to_ne_bytes(*self)
             }
         }
+        }
 
-        impl FromBytes for $T {
+        c0nst::c0nst! {
+        impl c0nst FromBytes for $T {
             type Bytes = [u8; $L];
 
             #[inline]
@@ -228,6 +243,7 @@ macro_rules! int_to_from_bytes_impl {
             fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
                 <$T>::from_ne_bytes(*bytes)
             }
+        }
         }
     };
 }

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -1,19 +1,23 @@
 use core::ops::{Add, Div, Mul, Rem, Shl, Shr, Sub};
 
+c0nst::c0nst! {
 /// Performs addition, returning `None` if overflow occurred.
-pub trait CheckedAdd: Sized + Add<Self, Output = Self> {
+pub c0nst trait CheckedAdd: Sized + [c0nst] Add<Self, Output = Self> {
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
     fn checked_add(&self, v: &Self) -> Option<Self>;
 }
+}
 
 macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, v: &$t) -> Option<$t> {
                 <$t>::$method(*self, *v)
             }
+        }
         }
     };
 }
@@ -32,11 +36,13 @@ checked_impl!(CheckedAdd, checked_add, i64);
 checked_impl!(CheckedAdd, checked_add, isize);
 checked_impl!(CheckedAdd, checked_add, i128);
 
+c0nst::c0nst! {
 /// Performs subtraction, returning `None` if overflow occurred.
-pub trait CheckedSub: Sized + Sub<Self, Output = Self> {
+pub c0nst trait CheckedSub: Sized + [c0nst] Sub<Self, Output = Self> {
     /// Subtracts two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
     fn checked_sub(&self, v: &Self) -> Option<Self>;
+}
 }
 
 checked_impl!(CheckedSub, checked_sub, u8);
@@ -53,11 +59,13 @@ checked_impl!(CheckedSub, checked_sub, i64);
 checked_impl!(CheckedSub, checked_sub, isize);
 checked_impl!(CheckedSub, checked_sub, i128);
 
+c0nst::c0nst! {
 /// Performs multiplication, returning `None` if overflow occurred.
-pub trait CheckedMul: Sized + Mul<Self, Output = Self> {
+pub c0nst trait CheckedMul: Sized + [c0nst] Mul<Self, Output = Self> {
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
     fn checked_mul(&self, v: &Self) -> Option<Self>;
+}
 }
 
 checked_impl!(CheckedMul, checked_mul, u8);
@@ -74,12 +82,14 @@ checked_impl!(CheckedMul, checked_mul, i64);
 checked_impl!(CheckedMul, checked_mul, isize);
 checked_impl!(CheckedMul, checked_mul, i128);
 
+c0nst::c0nst! {
 /// Performs division, returning `None` on division by zero or if overflow
 /// occurred.
-pub trait CheckedDiv: Sized + Div<Self, Output = Self> {
+pub c0nst trait CheckedDiv: Sized + [c0nst] Div<Self, Output = Self> {
     /// Divides two numbers, checking for overflow and division by
     /// zero. If any of that happens, `None` is returned.
     fn checked_div(&self, v: &Self) -> Option<Self>;
+}
 }
 
 checked_impl!(CheckedDiv, checked_div, u8);
@@ -96,16 +106,17 @@ checked_impl!(CheckedDiv, checked_div, i64);
 checked_impl!(CheckedDiv, checked_div, isize);
 checked_impl!(CheckedDiv, checked_div, i128);
 
+c0nst::c0nst! {
 /// Performs integral remainder, returning `None` on division by zero or if
 /// overflow occurred.
-pub trait CheckedRem: Sized + Rem<Self, Output = Self> {
+pub c0nst trait CheckedRem: Sized + [c0nst] Rem<Self, Output = Self> {
     /// Finds the remainder of dividing two numbers, checking for overflow and
     /// division by zero. If any of that happens, `None` is returned.
     ///
     /// # Examples
     ///
     /// ```
-    /// use num_traits::CheckedRem;
+    /// use const_num_traits::CheckedRem;
     /// use std::i32::MIN;
     ///
     /// assert_eq!(CheckedRem::checked_rem(&10, &7), Some(3));
@@ -119,6 +130,7 @@ pub trait CheckedRem: Sized + Rem<Self, Output = Self> {
     /// assert_eq!(CheckedRem::checked_rem(&MIN, &-1), None);
     /// ```
     fn checked_rem(&self, v: &Self) -> Option<Self>;
+}
 }
 
 checked_impl!(CheckedRem, checked_rem, u8);
@@ -137,24 +149,27 @@ checked_impl!(CheckedRem, checked_rem, i128);
 
 macro_rules! checked_impl_unary {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self) -> Option<$t> {
                 <$t>::$method(*self)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs negation, returning `None` if the result can't be represented.
-pub trait CheckedNeg: Sized {
+pub c0nst trait CheckedNeg: Sized {
     /// Negates a number, returning `None` for results that can't be represented, like signed `MIN`
     /// values that can't be positive, or non-zero unsigned values that can't be negative.
     ///
     /// # Examples
     ///
     /// ```
-    /// use num_traits::CheckedNeg;
+    /// use const_num_traits::CheckedNeg;
     /// use std::i32::MIN;
     ///
     /// assert_eq!(CheckedNeg::checked_neg(&1_i32), Some(-1));
@@ -165,6 +180,7 @@ pub trait CheckedNeg: Sized {
     /// assert_eq!(CheckedNeg::checked_neg(&1_u32), None);
     /// ```
     fn checked_neg(&self) -> Option<Self>;
+}
 }
 
 checked_impl_unary!(CheckedNeg, checked_neg, u8);
@@ -181,14 +197,15 @@ checked_impl_unary!(CheckedNeg, checked_neg, i64);
 checked_impl_unary!(CheckedNeg, checked_neg, isize);
 checked_impl_unary!(CheckedNeg, checked_neg, i128);
 
+c0nst::c0nst! {
 /// Performs shift left, returning `None` on shifts larger than or equal to
 /// the type width.
-pub trait CheckedShl: Sized + Shl<u32, Output = Self> {
+pub c0nst trait CheckedShl: Sized + [c0nst] Shl<u32, Output = Self> {
     /// Checked shift left. Computes `self << rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
     /// ```
-    /// use num_traits::CheckedShl;
+    /// use const_num_traits::CheckedShl;
     ///
     /// let x: u16 = 0x0001;
     ///
@@ -199,14 +216,17 @@ pub trait CheckedShl: Sized + Shl<u32, Output = Self> {
     /// ```
     fn checked_shl(&self, rhs: u32) -> Option<Self>;
 }
+}
 
 macro_rules! checked_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, rhs: u32) -> Option<$t> {
                 <$t>::$method(*self, rhs)
             }
+        }
         }
     };
 }
@@ -225,14 +245,15 @@ checked_shift_impl!(CheckedShl, checked_shl, i64);
 checked_shift_impl!(CheckedShl, checked_shl, isize);
 checked_shift_impl!(CheckedShl, checked_shl, i128);
 
+c0nst::c0nst! {
 /// Performs shift right, returning `None` on shifts larger than or equal to
 /// the type width.
-pub trait CheckedShr: Sized + Shr<u32, Output = Self> {
+pub c0nst trait CheckedShr: Sized + [c0nst] Shr<u32, Output = Self> {
     /// Checked shift right. Computes `self >> rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
     /// ```
-    /// use num_traits::CheckedShr;
+    /// use const_num_traits::CheckedShr;
     ///
     /// let x: u16 = 0x8000;
     ///
@@ -242,6 +263,7 @@ pub trait CheckedShr: Sized + Shr<u32, Output = Self> {
     /// assert_eq!(CheckedShr::checked_shr(&x, 16), None);
     /// ```
     fn checked_shr(&self, rhs: u32) -> Option<Self>;
+}
 }
 
 checked_shift_impl!(CheckedShr, checked_shr, u8);

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -1,6 +1,7 @@
 use core::ops::{Div, Rem};
 
-pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
+c0nst::c0nst! {
+pub c0nst trait Euclid: Sized + [c0nst] Div<Self, Output = Self> + [c0nst] Rem<Self, Output = Self> {
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
     ///
     /// This computes the integer `n` such that
@@ -11,7 +12,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::Euclid;
+    /// use const_num_traits::Euclid;
     ///
     /// let a: i32 = 7;
     /// let b: i32 = 4;
@@ -36,7 +37,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::Euclid;
+    /// use const_num_traits::Euclid;
     ///
     /// let a: i32 = 7;
     /// let b: i32 = 4;
@@ -55,7 +56,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     /// # Examples
     ///
     /// ```
-    /// # use num_traits::Euclid;
+    /// # use const_num_traits::Euclid;
     /// let x = 5u8;
     /// let y = 3u8;
     ///
@@ -68,8 +69,33 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
         (self.div_euclid(v), self.rem_euclid(v))
     }
 }
+}
 
 macro_rules! euclid_forward_impl {
+    ($($t:ty)*) => {$(
+        c0nst::c0nst! {
+        impl c0nst Euclid for $t {
+            #[inline]
+            fn div_euclid(&self, v: &$t) -> Self {
+                <$t>::div_euclid(*self, *v)
+            }
+
+            #[inline]
+            fn rem_euclid(&self, v: &$t) -> Self {
+                <$t>::rem_euclid(*self, *v)
+            }
+        }
+        }
+    )*}
+}
+
+euclid_forward_impl!(isize i8 i16 i32 i64 i128);
+euclid_forward_impl!(usize u8 u16 u32 u64 u128);
+
+// f32/f64 keep plain (non-const) impls: their inherent `div_euclid`/`rem_euclid`
+// aren't const fns yet, so a separate non-const macro path is used.
+#[cfg(feature = "std")]
+macro_rules! euclid_forward_impl_float {
     ($($t:ty)*) => {$(
         impl Euclid for $t {
             #[inline]
@@ -85,11 +111,8 @@ macro_rules! euclid_forward_impl {
     )*}
 }
 
-euclid_forward_impl!(isize i8 i16 i32 i64 i128);
-euclid_forward_impl!(usize u8 u16 u32 u64 u128);
-
 #[cfg(feature = "std")]
-euclid_forward_impl!(f32 f64);
+euclid_forward_impl_float!(f32 f64);
 
 #[cfg(not(feature = "std"))]
 impl Euclid for f32 {
@@ -135,7 +158,8 @@ impl Euclid for f64 {
     }
 }
 
-pub trait CheckedEuclid: Euclid {
+c0nst::c0nst! {
+pub c0nst trait CheckedEuclid: [c0nst] Euclid {
     /// Performs euclid division, returning `None` on division by zero or if
     /// overflow occurred.
     fn checked_div_euclid(&self, v: &Self) -> Option<Self>;
@@ -147,12 +171,10 @@ pub trait CheckedEuclid: Euclid {
     /// Returns both the quotient and remainder from checked Euclidean division,
     /// returning `None` on division by zero or if overflow occurred.
     ///
-    /// By default, it internally calls both `CheckedEuclid::checked_div_euclid` and `CheckedEuclid::checked_rem_euclid`,
-    /// but it can be overridden in order to implement some optimization.
     /// # Examples
     ///
     /// ```
-    /// # use num_traits::CheckedEuclid;
+    /// # use const_num_traits::CheckedEuclid;
     /// let x = 5u8;
     /// let y = 3u8;
     ///
@@ -161,14 +183,14 @@ pub trait CheckedEuclid: Euclid {
     ///
     /// assert_eq!(Some((div.unwrap(), rem.unwrap())), CheckedEuclid::checked_div_rem_euclid(&x, &y));
     /// ```
-    fn checked_div_rem_euclid(&self, v: &Self) -> Option<(Self, Self)> {
-        Some((self.checked_div_euclid(v)?, self.checked_rem_euclid(v)?))
-    }
+    fn checked_div_rem_euclid(&self, v: &Self) -> Option<(Self, Self)>;
+}
 }
 
 macro_rules! checked_euclid_forward_impl {
     ($($t:ty)*) => {$(
-        impl CheckedEuclid for $t {
+        c0nst::c0nst! {
+        impl c0nst CheckedEuclid for $t {
             #[inline]
             fn checked_div_euclid(&self, v: &$t) -> Option<Self> {
                 <$t>::checked_div_euclid(*self, *v)
@@ -178,6 +200,22 @@ macro_rules! checked_euclid_forward_impl {
             fn checked_rem_euclid(&self, v: &$t) -> Option<Self> {
                 <$t>::checked_rem_euclid(*self, *v)
             }
+
+            // `?` desugars through `Try`/`FromResidual` which aren't const;
+            // hand-roll the bail-out via `match`.
+            #[inline]
+            fn checked_div_rem_euclid(&self, v: &$t) -> Option<(Self, Self)> {
+                let d = match <$t>::checked_div_euclid(*self, *v) {
+                    Some(x) => x,
+                    None => return None,
+                };
+                let r = match <$t>::checked_rem_euclid(*self, *v) {
+                    Some(x) => x,
+                    None => return None,
+                };
+                Some((d, r))
+            }
+        }
         }
     )*}
 }
@@ -235,6 +273,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn euclid_float() {
         macro_rules! test_euclid {
             ($($t:ident)+) => {
@@ -242,14 +281,15 @@ mod tests {
                     {
                         let x: $t = 12.1;
                         let y: $t = 3.2;
+                        // Uses inherent `EPSILON` const now that `FloatCore` is gone.
                         assert!(Euclid::div_euclid(&x, &y) * y + Euclid::rem_euclid(&x, &y) - x
-                        <= 46.4 * <$t as crate::float::FloatCore>::epsilon());
+                        <= 46.4 * <$t>::EPSILON);
                         assert!(Euclid::div_euclid(&x, &-y) * -y + Euclid::rem_euclid(&x, &-y) - x
-                        <= 46.4 * <$t as crate::float::FloatCore>::epsilon());
+                        <= 46.4 * <$t>::EPSILON);
                         assert!(Euclid::div_euclid(&-x, &y) * y + Euclid::rem_euclid(&-x, &y) + x
-                        <= 46.4 * <$t as crate::float::FloatCore>::epsilon());
+                        <= 46.4 * <$t>::EPSILON);
                         assert!(Euclid::div_euclid(&-x, &-y) * -y + Euclid::rem_euclid(&-x, &-y) + x
-                        <= 46.4 * <$t as crate::float::FloatCore>::epsilon());
+                        <= 46.4 * <$t>::EPSILON);
                         assert_eq!((Euclid::div_euclid(&x, &y), Euclid::rem_euclid(&x, &y)), Euclid::div_rem_euclid(&x, &y));
                     }
                 )+

--- a/src/ops/inv.rs
+++ b/src/ops/inv.rs
@@ -1,5 +1,6 @@
+c0nst::c0nst! {
 /// Unary operator for retrieving the multiplicative inverse, or reciprocal, of a value.
-pub trait Inv {
+pub c0nst trait Inv {
     /// The result after applying the operator.
     type Output;
 
@@ -9,39 +10,48 @@ pub trait Inv {
     ///
     /// ```
     /// use std::f64::INFINITY;
-    /// use num_traits::Inv;
+    /// use const_num_traits::Inv;
     ///
     /// assert_eq!(7.0.inv() * 7.0, 1.0);
     /// assert_eq!((-0.0).inv(), -INFINITY);
     /// ```
     fn inv(self) -> Self::Output;
 }
+}
 
-impl Inv for f32 {
+c0nst::c0nst! {
+impl c0nst Inv for f32 {
     type Output = f32;
     #[inline]
     fn inv(self) -> f32 {
         1.0 / self
     }
 }
-impl Inv for f64 {
+}
+c0nst::c0nst! {
+impl c0nst Inv for f64 {
     type Output = f64;
     #[inline]
     fn inv(self) -> f64 {
         1.0 / self
     }
 }
-impl<'a> Inv for &'a f32 {
+}
+c0nst::c0nst! {
+impl<'a> c0nst Inv for &'a f32 {
     type Output = f32;
     #[inline]
     fn inv(self) -> f32 {
         1.0 / *self
     }
 }
-impl<'a> Inv for &'a f64 {
+}
+c0nst::c0nst! {
+impl<'a> c0nst Inv for &'a f64 {
     type Output = f64;
     #[inline]
     fn inv(self) -> f64 {
         1.0 / *self
     }
+}
 }

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -1,3 +1,4 @@
+c0nst::c0nst! {
 /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
 /// error, yielding a more accurate result than an unfused multiply-add.
 ///
@@ -20,20 +21,24 @@
 ///
 /// assert!(abs_difference <= 100.0 * f32::EPSILON);
 /// ```
-pub trait MulAdd<A = Self, B = Self> {
+pub c0nst trait MulAdd<A = Self, B = Self> {
     /// The resulting type after applying the fused multiply-add.
     type Output;
 
     /// Performs the fused multiply-add operation `(self * a) + b`
     fn mul_add(self, a: A, b: B) -> Self::Output;
 }
+}
 
+c0nst::c0nst! {
 /// The fused multiply-add assignment operation `*self = (*self * a) + b`
-pub trait MulAddAssign<A = Self, B = Self> {
+pub c0nst trait MulAddAssign<A = Self, B = Self> {
     /// Performs the fused multiply-add assignment operation `*self = (*self * a) + b`
     fn mul_add_assign(&mut self, a: A, b: B);
 }
+}
 
+// Float MulAdd / MulAddAssign delegate to `Float::mul_add`, which is non-const.
 #[cfg(any(feature = "std", feature = "libm"))]
 impl MulAdd<f32, f32> for f32 {
     type Output = Self;
@@ -56,13 +61,15 @@ impl MulAdd<f64, f64> for f64 {
 
 macro_rules! mul_add_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             type Output = Self;
 
             #[inline]
             fn mul_add(self, a: Self, b: Self) -> Self::Output {
                 (self * a) + b
             }
+        }
         }
     )*}
 }
@@ -88,11 +95,13 @@ impl MulAddAssign<f64, f64> for f64 {
 
 macro_rules! mul_add_assign_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn mul_add_assign(&mut self, a: Self, b: Self) {
                 *self = (*self * a) + b
             }
+        }
         }
     )*}
 }

--- a/src/ops/overflowing.rs
+++ b/src/ops/overflowing.rs
@@ -4,20 +4,24 @@ use core::{u128, u16, u32, u64, u8, usize};
 
 macro_rules! overflowing_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, v: &Self) -> (Self, bool) {
                 <$t>::$method(*self, *v)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs addition with a flag for overflow.
-pub trait OverflowingAdd: Sized + Add<Self, Output = Self> {
+pub c0nst trait OverflowingAdd: Sized + [c0nst] Add<Self, Output = Self> {
     /// Returns a tuple of the sum along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
     fn overflowing_add(&self, v: &Self) -> (Self, bool);
+}
 }
 
 overflowing_impl!(OverflowingAdd, overflowing_add, u8);
@@ -34,11 +38,13 @@ overflowing_impl!(OverflowingAdd, overflowing_add, i64);
 overflowing_impl!(OverflowingAdd, overflowing_add, isize);
 overflowing_impl!(OverflowingAdd, overflowing_add, i128);
 
+c0nst::c0nst! {
 /// Performs substraction with a flag for overflow.
-pub trait OverflowingSub: Sized + Sub<Self, Output = Self> {
+pub c0nst trait OverflowingSub: Sized + [c0nst] Sub<Self, Output = Self> {
     /// Returns a tuple of the difference along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
     fn overflowing_sub(&self, v: &Self) -> (Self, bool);
+}
 }
 
 overflowing_impl!(OverflowingSub, overflowing_sub, u8);
@@ -55,11 +61,13 @@ overflowing_impl!(OverflowingSub, overflowing_sub, i64);
 overflowing_impl!(OverflowingSub, overflowing_sub, isize);
 overflowing_impl!(OverflowingSub, overflowing_sub, i128);
 
+c0nst::c0nst! {
 /// Performs multiplication with a flag for overflow.
-pub trait OverflowingMul: Sized + Mul<Self, Output = Self> {
+pub c0nst trait OverflowingMul: Sized + [c0nst] Mul<Self, Output = Self> {
     /// Returns a tuple of the product along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
     fn overflowing_mul(&self, v: &Self) -> (Self, bool);
+}
 }
 
 overflowing_impl!(OverflowingMul, overflowing_mul, u8);

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -1,8 +1,9 @@
 use core::ops::{Add, Mul, Sub};
 
+c0nst::c0nst! {
 /// Saturating math operations. Deprecated, use `SaturatingAdd`, `SaturatingSub` and
 /// `SaturatingMul` instead.
-pub trait Saturating {
+pub c0nst trait Saturating {
     /// Saturating addition operator.
     /// Returns a+b, saturating at the numeric bounds instead of overflowing.
     fn saturating_add(self, v: Self) -> Self;
@@ -11,10 +12,12 @@ pub trait Saturating {
     /// Returns a-b, saturating at the numeric bounds instead of overflowing.
     fn saturating_sub(self, v: Self) -> Self;
 }
+}
 
 macro_rules! deprecated_saturating_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn saturating_add(self, v: Self) -> Self {
                 Self::saturating_add(self, v)
@@ -25,6 +28,7 @@ macro_rules! deprecated_saturating_impl {
                 Self::saturating_sub(self, v)
             }
         }
+        }
     )*}
 }
 
@@ -33,20 +37,24 @@ deprecated_saturating_impl!(Saturating for usize u8 u16 u32 u64 u128);
 
 macro_rules! saturating_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, v: &Self) -> Self {
                 <$t>::$method(*self, *v)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs addition that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingAdd: Sized + Add<Self, Output = Self> {
+pub c0nst trait SaturatingAdd: Sized + [c0nst] Add<Self, Output = Self> {
     /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_add(&self, v: &Self) -> Self;
+}
 }
 
 saturating_impl!(SaturatingAdd, saturating_add, u8);
@@ -63,11 +71,13 @@ saturating_impl!(SaturatingAdd, saturating_add, i64);
 saturating_impl!(SaturatingAdd, saturating_add, isize);
 saturating_impl!(SaturatingAdd, saturating_add, i128);
 
+c0nst::c0nst! {
 /// Performs subtraction that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingSub: Sized + Sub<Self, Output = Self> {
+pub c0nst trait SaturatingSub: Sized + [c0nst] Sub<Self, Output = Self> {
     /// Saturating subtraction. Computes `self - other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_sub(&self, v: &Self) -> Self;
+}
 }
 
 saturating_impl!(SaturatingSub, saturating_sub, u8);
@@ -84,11 +94,13 @@ saturating_impl!(SaturatingSub, saturating_sub, i64);
 saturating_impl!(SaturatingSub, saturating_sub, isize);
 saturating_impl!(SaturatingSub, saturating_sub, i128);
 
+c0nst::c0nst! {
 /// Performs multiplication that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingMul: Sized + Mul<Self, Output = Self> {
+pub c0nst trait SaturatingMul: Sized + [c0nst] Mul<Self, Output = Self> {
     /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_mul(&self, v: &Self) -> Self;
+}
 }
 
 saturating_impl!(SaturatingMul, saturating_mul, u8);

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -3,28 +3,34 @@ use core::ops::{Add, Mul, Neg, Shl, Shr, Sub};
 
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, v: &Self) -> Self {
                 <$t>::$method(*self, *v)
             }
         }
+        }
     };
     ($trait_name:ident, $method:ident, $t:ty, $rhs:ty) => {
-        impl $trait_name<$rhs> for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name<$rhs> for $t {
             #[inline]
             fn $method(&self, v: &$rhs) -> Self {
                 <$t>::$method(*self, *v)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs addition that wraps around on overflow.
-pub trait WrappingAdd: Sized + Add<Self, Output = Self> {
+pub c0nst trait WrappingAdd: Sized + [c0nst] Add<Self, Output = Self> {
     /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of
     /// the type.
     fn wrapping_add(&self, v: &Self) -> Self;
+}
 }
 
 wrapping_impl!(WrappingAdd, wrapping_add, u8);
@@ -41,11 +47,13 @@ wrapping_impl!(WrappingAdd, wrapping_add, i64);
 wrapping_impl!(WrappingAdd, wrapping_add, isize);
 wrapping_impl!(WrappingAdd, wrapping_add, i128);
 
+c0nst::c0nst! {
 /// Performs subtraction that wraps around on overflow.
-pub trait WrappingSub: Sized + Sub<Self, Output = Self> {
+pub c0nst trait WrappingSub: Sized + [c0nst] Sub<Self, Output = Self> {
     /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary
     /// of the type.
     fn wrapping_sub(&self, v: &Self) -> Self;
+}
 }
 
 wrapping_impl!(WrappingSub, wrapping_sub, u8);
@@ -62,11 +70,13 @@ wrapping_impl!(WrappingSub, wrapping_sub, i64);
 wrapping_impl!(WrappingSub, wrapping_sub, isize);
 wrapping_impl!(WrappingSub, wrapping_sub, i128);
 
+c0nst::c0nst! {
 /// Performs multiplication that wraps around on overflow.
-pub trait WrappingMul: Sized + Mul<Self, Output = Self> {
+pub c0nst trait WrappingMul: Sized + [c0nst] Mul<Self, Output = Self> {
     /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary
     /// of the type.
     fn wrapping_mul(&self, v: &Self) -> Self;
+}
 }
 
 wrapping_impl!(WrappingMul, wrapping_mul, u8);
@@ -85,17 +95,20 @@ wrapping_impl!(WrappingMul, wrapping_mul, i128);
 
 macro_rules! wrapping_unary_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self) -> $t {
                 <$t>::$method(*self)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs a negation that does not panic.
-pub trait WrappingNeg: Sized {
+pub c0nst trait WrappingNeg: Sized {
     /// Wrapping (modular) negation. Computes `-self`,
     /// wrapping around at the boundary of the type.
     ///
@@ -107,13 +120,14 @@ pub trait WrappingNeg: Sized {
     /// `MAX` is the corresponding signed type's maximum.
     ///
     /// ```
-    /// use num_traits::WrappingNeg;
+    /// use const_num_traits::WrappingNeg;
     ///
     /// assert_eq!(100i8.wrapping_neg(), -100);
     /// assert_eq!((-100i8).wrapping_neg(), 100);
     /// assert_eq!((-128i8).wrapping_neg(), -128); // wrapped!
     /// ```
     fn wrapping_neg(&self) -> Self;
+}
 }
 
 wrapping_unary_impl!(WrappingNeg, wrapping_neg, u8);
@@ -131,23 +145,26 @@ wrapping_unary_impl!(WrappingNeg, wrapping_neg, i128);
 
 macro_rules! wrapping_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        c0nst::c0nst! {
+        impl c0nst $trait_name for $t {
             #[inline]
             fn $method(&self, rhs: u32) -> $t {
                 <$t>::$method(*self, rhs)
             }
         }
+        }
     };
 }
 
+c0nst::c0nst! {
 /// Performs a left shift that does not panic.
-pub trait WrappingShl: Sized + Shl<usize, Output = Self> {
+pub c0nst trait WrappingShl: Sized + [c0nst] Shl<usize, Output = Self> {
     /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
     ///
     /// ```
-    /// use num_traits::WrappingShl;
+    /// use const_num_traits::WrappingShl;
     ///
     /// let x: u16 = 0x0001;
     ///
@@ -157,6 +174,7 @@ pub trait WrappingShl: Sized + Shl<usize, Output = Self> {
     /// assert_eq!(WrappingShl::wrapping_shl(&x, 16), 0x0001);
     /// ```
     fn wrapping_shl(&self, rhs: u32) -> Self;
+}
 }
 
 wrapping_shift_impl!(WrappingShl, wrapping_shl, u8);
@@ -173,14 +191,15 @@ wrapping_shift_impl!(WrappingShl, wrapping_shl, i64);
 wrapping_shift_impl!(WrappingShl, wrapping_shl, isize);
 wrapping_shift_impl!(WrappingShl, wrapping_shl, i128);
 
+c0nst::c0nst! {
 /// Performs a right shift that does not panic.
-pub trait WrappingShr: Sized + Shr<usize, Output = Self> {
+pub c0nst trait WrappingShr: Sized + [c0nst] Shr<usize, Output = Self> {
     /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
     ///
     /// ```
-    /// use num_traits::WrappingShr;
+    /// use const_num_traits::WrappingShr;
     ///
     /// let x: u16 = 0x8000;
     ///
@@ -190,6 +209,7 @@ pub trait WrappingShr: Sized + Shr<usize, Output = Self> {
     /// assert_eq!(WrappingShr::wrapping_shr(&x, 16), 0x8000);
     /// ```
     fn wrapping_shr(&self, rhs: u32) -> Self;
+}
 }
 
 wrapping_shift_impl!(WrappingShr, wrapping_shr, u8);
@@ -206,7 +226,8 @@ wrapping_shift_impl!(WrappingShr, wrapping_shr, i64);
 wrapping_shift_impl!(WrappingShr, wrapping_shr, isize);
 wrapping_shift_impl!(WrappingShr, wrapping_shr, i128);
 
-// Well this is a bit funny, but all the more appropriate.
+// Wrapping<T> blanket impls stay non-const: std's `Add`/`Sub`/`Mul`/`Neg`/`Shl`/`Shr`
+// impls for `Wrapping<T>` are not const-trait impls (same situation as Num).
 impl<T: WrappingAdd> WrappingAdd for Wrapping<T>
 where
     Wrapping<T>: Add<Output = Wrapping<T>>,

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -12,7 +12,7 @@ pub trait Pow<RHS> {
     /// # Examples
     ///
     /// ```
-    /// use num_traits::Pow;
+    /// use const_num_traits::Pow;
     /// assert_eq!(Pow::pow(10u32, 2u32), 100);
     /// ```
     fn pow(self, rhs: RHS) -> Self::Output;
@@ -169,7 +169,7 @@ mod float_impls {
 /// # Example
 ///
 /// ```rust
-/// use num_traits::pow;
+/// use const_num_traits::pow;
 ///
 /// assert_eq!(pow(2i8, 4), 16);
 /// assert_eq!(pow(6u8, 3), 216);
@@ -209,7 +209,7 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
 /// # Example
 ///
 /// ```rust
-/// use num_traits::checked_pow;
+/// use const_num_traits::checked_pow;
 ///
 /// assert_eq!(checked_pow(2i8, 4), Some(16));
 /// assert_eq!(checked_pow(7i8, 8), None);

--- a/src/real.rs
+++ b/src/real.rs
@@ -18,7 +18,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_value();
@@ -30,7 +30,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_positive_value();
@@ -42,7 +42,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns epsilon, a small positive value.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::epsilon();
@@ -59,7 +59,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::max_value();
@@ -70,7 +70,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 3.99;
     /// let g = 3.0;
@@ -83,7 +83,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 3.01;
     /// let g = 4.0;
@@ -97,7 +97,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `0.0`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 3.3;
     /// let g = -3.3;
@@ -110,7 +110,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 3.3;
     /// let g = -3.7;
@@ -123,7 +123,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 3.5;
     /// let y = -3.5;
@@ -139,7 +139,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is `Float::nan()`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = 3.5;
@@ -151,7 +151,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
     ///
-    /// assert!(::num_traits::Float::is_nan(f64::NAN.abs()));
+    /// assert!(::const_num_traits::Float::is_nan(f64::NAN.abs()));
     /// ```
     fn abs(self) -> Self;
 
@@ -162,7 +162,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = 3.5;
@@ -178,7 +178,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let neg_nan: f64 = -f64::NAN;
@@ -196,7 +196,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
@@ -217,7 +217,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let m = 10.0;
     /// let x = 4.0;
@@ -233,7 +233,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
@@ -247,7 +247,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
@@ -259,7 +259,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Raise a number to a real number power.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
@@ -277,7 +277,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let positive = 4.0;
     /// let negative = -4.0;
@@ -285,14 +285,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (positive.sqrt() - 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// assert!(::num_traits::Float::is_nan(negative.sqrt()));
+    /// assert!(::const_num_traits::Float::is_nan(negative.sqrt()));
     /// ```
     fn sqrt(self) -> Self;
 
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -308,7 +308,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 2.0;
     ///
@@ -326,7 +326,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -346,7 +346,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let ten = 10.0;
     /// let two = 2.0;
@@ -369,7 +369,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let two = 2.0;
     ///
@@ -388,7 +388,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let ten = 10.0;
     ///
@@ -428,7 +428,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -440,7 +440,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -455,7 +455,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * Else: `self - other`
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 3.0;
     /// let y = -3.0;
@@ -471,7 +471,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Take the cubic root of a number.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 8.0;
     ///
@@ -486,7 +486,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let y = 3.0;
@@ -501,7 +501,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/2.0;
@@ -515,7 +515,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = 2.0*f64::consts::PI;
@@ -529,7 +529,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -549,7 +549,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if the number is outside the range [-1, 1].
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 2.0;
@@ -571,7 +571,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if the number is outside the range [-1, 1].
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 4.0;
@@ -587,7 +587,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let f = 1.0;
     ///
@@ -606,7 +606,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let pi = f64::consts::PI;
@@ -631,7 +631,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -649,7 +649,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is close to zero.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 7.0;
     ///
@@ -669,7 +669,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if `self-1 <= 0`.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::E - 1.0;
@@ -684,7 +684,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -702,7 +702,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -720,7 +720,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -738,7 +738,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let f = x.sinh().asinh();
@@ -752,7 +752,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let f = x.cosh().acosh();
@@ -766,7 +766,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::real::Real;
+    /// use const_num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -4,8 +4,9 @@ use core::ops::Neg;
 use crate::float::FloatCore;
 use crate::Num;
 
+c0nst::c0nst! {
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
-pub trait Signed: Sized + Num + Neg<Output = Self> {
+pub c0nst trait Signed: Sized + [c0nst] Num + [c0nst] Neg<Output = Self> {
     /// Computes the absolute value.
     ///
     /// For `f32` and `f64`, `NaN` will be returned if the number is `NaN`.
@@ -40,10 +41,12 @@ pub trait Signed: Sized + Num + Neg<Output = Self> {
     /// Returns true if the number is negative and false if the number is zero or positive.
     fn is_negative(&self) -> bool;
 }
+}
 
 macro_rules! signed_impl {
     ($($t:ty)*) => ($(
-        impl Signed for $t {
+        c0nst::c0nst! {
+        impl c0nst Signed for $t {
             #[inline]
             fn abs(&self) -> $t {
                 if self.is_negative() { -*self } else { *self }
@@ -69,11 +72,14 @@ macro_rules! signed_impl {
             #[inline]
             fn is_negative(&self) -> bool { *self < 0 }
         }
+        }
     )*)
 }
 
 signed_impl!(isize i8 i16 i32 i64 i128);
 
+// `Wrapping<T>: Num` is itself a non-const impl (std's `PartialEq` on
+// `Wrapping<T>` isn't const), so this stays non-const.
 impl<T: Signed> Signed for Wrapping<T>
 where
     Wrapping<T>: Num + Neg<Output = Wrapping<T>>,
@@ -104,6 +110,7 @@ where
     }
 }
 
+// Float Signed stays non-const: `FloatCore::signum` isn't const-callable.
 macro_rules! signed_float_impl {
     ($t:ty) => {
         impl Signed for $t {
@@ -153,25 +160,30 @@ macro_rules! signed_float_impl {
 signed_float_impl!(f32);
 signed_float_impl!(f64);
 
+c0nst::c0nst! {
 /// Computes the absolute value.
 ///
 /// For `f32` and `f64`, `NaN` will be returned if the number is `NaN`
 ///
 /// For signed integers, `::MIN` will be returned if the number is `::MIN`.
 #[inline(always)]
-pub fn abs<T: Signed>(value: T) -> T {
+pub c0nst fn abs<T: [c0nst] Signed + [c0nst] Destruct>(value: T) -> T {
     value.abs()
 }
+}
 
+c0nst::c0nst! {
 /// The positive difference of two numbers.
 ///
 /// Returns zero if `x` is less than or equal to `y`, otherwise the difference
 /// between `x` and `y` is returned.
 #[inline(always)]
-pub fn abs_sub<T: Signed>(x: T, y: T) -> T {
+pub c0nst fn abs_sub<T: [c0nst] Signed + [c0nst] Destruct>(x: T, y: T) -> T {
     x.abs_sub(&y)
 }
+}
 
+c0nst::c0nst! {
 /// Returns the sign of the number.
 ///
 /// For `f32` and `f64`:
@@ -186,21 +198,27 @@ pub fn abs_sub<T: Signed>(x: T, y: T) -> T {
 /// * `1` if the number is positive
 /// * `-1` if the number is negative
 #[inline(always)]
-pub fn signum<T: Signed>(value: T) -> T {
+pub c0nst fn signum<T: [c0nst] Signed + [c0nst] Destruct>(value: T) -> T {
     value.signum()
 }
+}
 
+c0nst::c0nst! {
 /// A trait for values which cannot be negative
-pub trait Unsigned: Num {}
+pub c0nst trait Unsigned: [c0nst] Num {}
+}
 
 macro_rules! empty_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
-        impl $name for $t {}
+        c0nst::c0nst! {
+        impl c0nst $name for $t {}
+        }
     )*)
 }
 
 empty_trait_impl!(Unsigned for usize u8 u16 u32 u64 u128);
 
+// Same `Wrapping<T>: Num` story as `Signed`: non-const blanket impl.
 impl<T: Unsigned> Unsigned for Wrapping<T> where Wrapping<T>: Num {}
 
 #[test]

--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -1,9 +1,9 @@
-//! Tests of `num_traits::cast`.
+//! Tests of `const_num_traits::cast`.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use num_traits::cast::*;
-use num_traits::Bounded;
+use const_num_traits::cast::*;
+use const_num_traits::Bounded;
 
 use core::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
@@ -546,14 +546,51 @@ fn newtype_from_primitive() {
     #[derive(PartialEq, Debug)]
     struct New<T>(T);
 
-    // minimal impl
+    // `FromPrimitive` no longer ships defaults (the const port stripped them
+    // because `Option::and_then` isn't a const fn); each method delegates
+    // directly to the inner conversion.
     impl<T: FromPrimitive> FromPrimitive for New<T> {
+        fn from_isize(n: isize) -> Option<Self> {
+            T::from_isize(n).map(New)
+        }
+        fn from_i8(n: i8) -> Option<Self> {
+            T::from_i8(n).map(New)
+        }
+        fn from_i16(n: i16) -> Option<Self> {
+            T::from_i16(n).map(New)
+        }
+        fn from_i32(n: i32) -> Option<Self> {
+            T::from_i32(n).map(New)
+        }
         fn from_i64(n: i64) -> Option<Self> {
             T::from_i64(n).map(New)
         }
-
+        fn from_i128(n: i128) -> Option<Self> {
+            T::from_i128(n).map(New)
+        }
+        fn from_usize(n: usize) -> Option<Self> {
+            T::from_usize(n).map(New)
+        }
+        fn from_u8(n: u8) -> Option<Self> {
+            T::from_u8(n).map(New)
+        }
+        fn from_u16(n: u16) -> Option<Self> {
+            T::from_u16(n).map(New)
+        }
+        fn from_u32(n: u32) -> Option<Self> {
+            T::from_u32(n).map(New)
+        }
         fn from_u64(n: u64) -> Option<Self> {
             T::from_u64(n).map(New)
+        }
+        fn from_u128(n: u128) -> Option<Self> {
+            T::from_u128(n).map(New)
+        }
+        fn from_f32(n: f32) -> Option<Self> {
+            T::from_f32(n).map(New)
+        }
+        fn from_f64(n: f64) -> Option<Self> {
+            T::from_f64(n).map(New)
         }
     }
 
@@ -587,14 +624,50 @@ fn newtype_to_primitive() {
     #[derive(PartialEq, Debug)]
     struct New<T>(T);
 
-    // minimal impl
+    // `ToPrimitive` no longer ships defaults (the const port stripped them);
+    // each method delegates directly to the inner conversion.
     impl<T: ToPrimitive> ToPrimitive for New<T> {
+        fn to_isize(&self) -> Option<isize> {
+            self.0.to_isize()
+        }
+        fn to_i8(&self) -> Option<i8> {
+            self.0.to_i8()
+        }
+        fn to_i16(&self) -> Option<i16> {
+            self.0.to_i16()
+        }
+        fn to_i32(&self) -> Option<i32> {
+            self.0.to_i32()
+        }
         fn to_i64(&self) -> Option<i64> {
             self.0.to_i64()
         }
-
+        fn to_i128(&self) -> Option<i128> {
+            self.0.to_i128()
+        }
+        fn to_usize(&self) -> Option<usize> {
+            self.0.to_usize()
+        }
+        fn to_u8(&self) -> Option<u8> {
+            self.0.to_u8()
+        }
+        fn to_u16(&self) -> Option<u16> {
+            self.0.to_u16()
+        }
+        fn to_u32(&self) -> Option<u32> {
+            self.0.to_u32()
+        }
         fn to_u64(&self) -> Option<u64> {
             self.0.to_u64()
+        }
+        fn to_u128(&self) -> Option<u128> {
+            self.0.to_u128()
+        }
+        fn to_f32(&self) -> Option<f32> {
+            self.0.to_f32()
+        }
+        fn to_f64(&self) -> Option<f64> {
+            self.0.to_f64()
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Port numeric trait APIs to a const-friendly fork (`const-num-traits`) using the `c0nst` macro ecosystem, while keeping non-const fallbacks where required.

Enhancements:
- Make core numeric traits and ops (e.g., Num, PrimInt, ToPrimitive/FromPrimitive, NumCast, AsPrimitive, Euclid, Checked*, Wrapping*, Saturating*, Overflowing*, bounds, sign) usable in const contexts via `c0nst` traits and implementations.
- Adjust implementations and helper macros to avoid non-const operations (e.g., `Option::map/and_then`, `?`, unsafe float-to-int casts) where necessary, hand-rolling const-compatible logic while retaining behavior.
- Split float- and wrapper-based implementations where std library traits or methods are not yet const, keeping them as non-const to preserve functionality.

Build:
- Rename the crate to `const-num-traits`, add the `c0nst` dependency with an optional `nightly` feature, and update metadata (docs URL, repository, version, nightly cfg attributes).

Documentation:
- Rename crate and documentation paths from `num_traits` to `const_num_traits` throughout public docs and examples, and update crate-level docs and notes accordingly.

Tests:
- Update tests relying on default `ToPrimitive`/`FromPrimitive` methods to provide explicit implementations now that those defaults are removed for const compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Numeric traits and arithmetic/utility operations are now const-evaluable for compile-time use (including `clamp`/`clamp_min`/`clamp_max`, and numeric casting).

* **Breaking Changes**
  * Public trait and function const-compatibility has changed the way traits are defined/implemented in user code.
  * `Zero`/`One` now require explicit `set_*` and `is_*` methods.

* **Documentation**
  * Updated examples to use the const-compatible package path/identity.

* **CI / Maintenance**
  * Raised the tested Rust MSRV to 1.86.0.
  * Added/updated tests for const casting and bounded traits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->