### PR TITLE
Pre-publish hygiene: packaging whitelist, docs.rs ct, drop downstream refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,21 @@ repository = "https://github.com/kaidokert/num-traits"
 name = "const-num-traits"
 version = "0.1.0"
 readme = "README.md"
-exclude = ["/.github/*", "/.pre-commit-config.yaml"]
+# Include-list of the files that ship. Anything not listed here is never packaged.
+include = [
+    "/src",
+    "/examples",
+    "/tests",
+    "/README.md",
+    "/LICENSE-APACHE",
+    "/LICENSE-MIT",
+]
 edition = "2024"
 rust-version = "1.86"
 
 [package.metadata.docs.rs]
-features = ["std"]
-rustdoc-args = ["--generate-link-to-definition"]
+features = ["std", "ct"]
+rustdoc-args = ["--generate-link-to-definition", "--cfg", "docsrs"]
 
 [dependencies]
 c0nst = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fork of [`num-traits`](https://github.com/rust-num/num-traits). It:
   nightly toolchain the same surface becomes `const trait`, usable in `const`
   (via the [`c0nst`](https://crates.io/crates/c0nst) macro);
 - exposes newer `core` integer and float operations that `num-traits` yet does not,
-  such as `wide_mul`;
+  such as `widening_mul`;
 - is intentionally API-breaking with `num-traits`, to keep the `const` and
   non-`const` views of the API as close as possible.
 

--- a/examples/typestates.rs
+++ b/examples/typestates.rs
@@ -94,8 +94,8 @@ fn nonmin() {
 fn odd_modulus() {
     // a parsed/odd modulus, proven once
     let m = Odd::<u64>::new(0xFFFF_FFFF_FFFF_FFC5).expect("a large odd prime");
-    // `Odd ⇒ non-zero` (zero is even), so this one proof covers both
-    // preconditions a Montgomery-style modulus needs.
+    // `Odd ⇒ non-zero` (zero is even), so this one proof covers both the
+    // "odd" and "non-zero" preconditions at once.
     assert_eq!(m.get() & 1, 1);
 
     assert!(Odd::<u64>::new(0).is_none()); // zero is even

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@
 //!
 //! The `const-num-traits` crate is tested for rustc 1.86 and greater.
 
-#![doc(html_root_url = "https://docs.rs/const-num-traits/0.1")]
 #![deny(unconditional_recursion)]
 // By-value receivers mirror core's inherent methods, so `is_*` predicates take
 // `self` by value — intentional, though clippy's `wrong_self_convention` flags it.
@@ -59,6 +58,9 @@
     feature = "nightly",
     feature(const_trait_impl, const_ops, const_cmp, const_destruct)
 )]
+// docs.rs sets `--cfg docsrs`; enable `doc(cfg(...))` so feature-gated items
+// (e.g. the `ct` module) render with a "Available on crate feature …" label.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Need to explicitly bring the crate in for inherent float methods
 #[cfg(feature = "std")]
@@ -93,6 +95,7 @@ pub use crate::ops::convert::{
     Truncate, UnsignedAbs, Widen, WrappingCast,
 };
 #[cfg(feature = "ct")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ct")))]
 pub use crate::ops::ct::{
     CtCheckedAdd, CtCheckedMul, CtCheckedNeg, CtCheckedSignedDiff, CtCheckedSub, CtIsPowerOfTwo,
     CtIsZero, CtParity,
@@ -129,6 +132,7 @@ pub use crate::ops::strict::{
     StrictShl, StrictShr, StrictSub,
 };
 #[cfg(feature = "ct")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ct")))]
 pub use crate::ops::typestate::CtNonZero;
 pub use crate::ops::typestate::{
     BitIndex, BitIndexOps, DivNonZero, Even, Finite, HasNonZero, NonMin, NonNegative, Odd,
@@ -177,6 +181,7 @@ pub mod prelude {
     pub use crate::ops::clmul::*;
     pub use crate::ops::convert::*;
     #[cfg(feature = "ct")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ct")))]
     pub use crate::ops::ct::*;
     pub use crate::ops::euclid::*;
     pub use crate::ops::float_ops::*;
@@ -197,6 +202,7 @@ pub mod prelude {
     pub use crate::ops::sqrt::*;
     pub use crate::ops::strict::*;
     #[cfg(feature = "ct")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ct")))]
     pub use crate::ops::typestate::CtNonZero;
     pub use crate::ops::typestate::{BitIndexOps, DivNonZero, HasNonZero, PowerOfTwoOps};
     pub use crate::ops::wrapping::*;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -5,6 +5,7 @@ pub mod checked;
 pub mod clmul;
 pub mod convert;
 #[cfg(feature = "ct")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ct")))]
 pub mod ct;
 pub mod euclid;
 pub mod float_ops;

--- a/src/ops/parity.rs
+++ b/src/ops/parity.rs
@@ -2,7 +2,7 @@
 //!
 //! std has no inherent `is_odd`/`is_even` (they live in `num-integer`'s
 //! `Integer` bundle); this is the atom version. Unlike a blanket impl over
-//! `BitAnd + One + PartialEq + Clone` (modmath's current fallback shape),
+//! `BitAnd + One + PartialEq + Clone` (the usual generic fallback shape),
 //! a per-type trait needs no `PartialEq`/`Clone` bounds — important both
 //! for constant-time types that deliberately don't expose `PartialEq` and
 //! for multi-limb bigints, which can answer from the lowest limb alone

--- a/src/ops/typestate.rs
+++ b/src/ops/typestate.rs
@@ -14,7 +14,7 @@
 //! - [`NonNegative`] / [`Positive`] (signed): unsigned cast, `abs`, `isqrt`, plus
 //!   `const` narrowings into each other / `NonZero` / `NonMin`.
 //! - [`NonMin`] (signed): total `neg`/`abs` and total signed division.
-//! - [`Odd`] / [`Even`]: bare proofs (consumer lives in the modmath layer).
+//! - [`Odd`] / [`Even`]: bare proofs (no consuming op in this crate).
 //! - [`Finite`] (floats): a total order (`Ord`/`Eq`) that bare floats lack.
 //!
 //! With the `ct` feature, families with a *secret-derived* predicate also gain a
@@ -677,12 +677,10 @@ nonmin_impl!(i8, i16, i32, i64, i128, isize);
 
 /// Proof that a value is odd.
 ///
-/// A **bare** typestate: it has no consuming op *in this crate*. Its consumer
-/// (e.g. an odd-modulus Montgomery constructor) lives in the modular-arithmetic
-/// layer, where the precondition is actually spent. It ships here because that
-/// is where the predicate ([`Parity`]) lives. `Odd` covers both the "non-zero"
-/// and "odd" preconditions a Montgomery modulus needs — zero is even — so no
-/// separate `OddNonZero` is required.
+/// A **bare** typestate: it carries the proof but has no consuming op in this
+/// crate. It ships here because that is where its predicate ([`Parity`]) lives.
+/// Note that `Odd` also implies non-zero — zero is even — so it doubles as a
+/// "non-zero and odd" proof without a separate `OddNonZero` type.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Odd<T>(T);

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -72,9 +72,8 @@ impl Personality for Nct {
 ///
 /// Selects constant-time implementations of operation primitives — bodies
 /// whose execution time and memory access pattern do not depend on operand
-/// values. Appropriate for code that handles secret values (signing,
-/// scalar multiplication on secret scalars, Montgomery multiplication on
-/// secret operands).
+/// values. Appropriate for code that handles secret values, where
+/// operand-dependent timing or memory access would leak them.
 ///
 /// Constant-time-only APIs (e.g. `subtle::ConditionallySelectable`,
 /// `ConstantTimeEq`) should be exposed only for the `Ct` variant — wrong-


### PR DESCRIPTION
Getting the package contents and rendered docs into their intended shape before the first crates.io publish (0.1.0).

## Packaging
- Replace the `exclude` list with an `include` whitelist in `Cargo.toml`. `cargo package` was picking up untracked local design docs (`CLAUDE.md`, `DESIGN.md`, `MIGRATION.md`, …) and would have shipped them in the `.crate`. Whitelisting `src`/`examples`/`tests`/`README`/licenses means future local scratch files can never leak into a published crate. Verified with `cargo package --list` and `cargo publish --dry-run` (47 files, no strays).

## docs.rs
- Build docs with `features = ["std", "ct"]` + `--cfg docsrs`, and add `doc(cfg(feature = "ct"))` (behind the `doc_cfg` feature, active only under `--cfg docsrs`) so the `ct`-gated items render on docs.rs with an "Available on crate feature `ct`" label instead of being hidden entirely.
- Drop `#![doc(html_root_url = ".../0.1")]` — a per-release maintenance chore the ecosystem has abandoned; rustdoc resolves intra-doc links without it.

## Docs accuracy
- README: `wide_mul` → `widening_mul` (the actual public method name; `wide_mul_u128` is only a `pub(crate)` helper).
- Erase references to specific downstream consumers from doc comments (`parity.rs`, `typestate.rs`, `personality.rs`, `examples/typestates.rs`). A numeric crate should justify its design on numeric properties, not by naming a particular consumer or crypto-domain algorithm.

No API or behavior changes — public surface audited with `cargo public-api` (no additions/removals; internal helpers stay `pub(crate)`).

## Summary by Sourcery

Prepare crate packaging and docs.rs configuration for initial publish without changing the public API.

Enhancements:
- Restrict published crate contents via an explicit include whitelist to avoid shipping local scratch/design files.
- Adjust docs.rs build configuration to document the `ct` feature-gated items with proper feature labels and remove the deprecated `html_root_url` attribute.
- Clarify documentation and examples by correcting method naming in the README and rephrasing comments to focus on numeric properties rather than specific downstream consumers.

Build:
- Update Cargo.toml packaging and docs.rs metadata to control shipped files and docs build behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved crate and API docs so feature-gated items are clearly labeled on generated documentation.
  * Refreshed wording for parity, typestate proofs, and constant-time guidance for clearer “bare typestate” and timing-safety explanations.
  * Updated the README example to reference `widening_mul` instead of `wide_mul`.

* **Chores**
  * Refined published crate contents and documentation build settings to ensure more complete docs packaging and docs.rs compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->