### PR TITLE
Add HasPersonality projection; 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kaidokert/num-traits"
 name = "const-num-traits"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 # Include-list of the files that ship. Anything not listed here is never packaged.
 include = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub use crate::ops::wrapping::{
     WrappingAbs, WrappingAdd, WrappingDiv, WrappingMul, WrappingNeg, WrappingPow, WrappingRem,
     WrappingShl, WrappingShr, WrappingSub,
 };
-pub use crate::personality::{Ct, Nct, Personality, PersonalityMarker, PersonalityTag};
+pub use crate::personality::{Ct, HasPersonality, Nct, Personality, PersonalityMarker, PersonalityTag};
 pub use crate::pow::{Pow, checked_pow, pow};
 pub use crate::sign::{Signed, Signum, Unsigned, abs, abs_sub, signum};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,9 @@ pub use crate::ops::wrapping::{
     WrappingAbs, WrappingAdd, WrappingDiv, WrappingMul, WrappingNeg, WrappingPow, WrappingRem,
     WrappingShl, WrappingShr, WrappingSub,
 };
-pub use crate::personality::{Ct, HasPersonality, Nct, Personality, PersonalityMarker, PersonalityTag};
+pub use crate::personality::{
+    Ct, HasPersonality, Nct, Personality, PersonalityMarker, PersonalityTag,
+};
 pub use crate::pow::{Pow, checked_pow, pow};
 pub use crate::sign::{Signed, Signum, Unsigned, abs, abs_sub, signum};
 

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -93,9 +93,12 @@ pub type PersonalityMarker<P> = PhantomData<fn() -> P>;
 /// Projects a carrier type's [`Personality`] at the type level.
 ///
 /// Implemented by carrier types whose implementation shape is selected
-/// by a personality parameter (e.g. a bigint's `FixedUInt<W, N, P>`
-/// projects `P`), and by the primitive integers, which are always
-/// [`Nct`] — their arithmetic is variable-time on common hardware.
+/// by a personality parameter (a bigint parameterized over its
+/// personality projects that parameter), and by the primitive integers,
+/// which project [`Nct`]: they expose a single hardware-backed
+/// implementation, select no constant-time variant, and make no
+/// constant-time guarantee — integer division in particular has
+/// operand-dependent latency on common CPUs.
 ///
 /// Consumers bound on the projection to gate algorithm choice by
 /// personality: `T: HasPersonality<P = Nct>` admits a type into

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -90,6 +90,35 @@ impl Personality for Ct {
 /// Use as `_p: PersonalityMarker<P>` in struct definitions.
 pub type PersonalityMarker<P> = PhantomData<fn() -> P>;
 
+/// Projects a carrier type's [`Personality`] at the type level.
+///
+/// Implemented by carrier types whose implementation shape is selected
+/// by a personality parameter (e.g. a bigint's `FixedUInt<W, N, P>`
+/// projects `P`), and by the primitive integers, which are always
+/// [`Nct`] — their arithmetic is variable-time on common hardware.
+///
+/// Consumers bound on the projection to gate algorithm choice by
+/// personality: `T: HasPersonality<P = Nct>` admits a type into
+/// variable-time code paths, `P = Ct` into constant-time-only ones.
+/// The declaration is the carrier author's contract; there is no way
+/// to verify it structurally.
+pub trait HasPersonality {
+    /// The carrier's personality.
+    type P: Personality;
+}
+
+macro_rules! impl_has_personality_nct {
+    ($($t:ty),*) => {
+        $(
+            impl HasPersonality for $t {
+                type P = Nct;
+            }
+        )*
+    };
+}
+
+impl_has_personality_nct!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,6 +129,16 @@ mod tests {
         assert_eq!(Ct::TAG, PersonalityTag::Ct);
         assert_eq!(Nct, Nct);
         assert_eq!(Ct, Ct);
+    }
+
+    #[test]
+    fn has_personality_projects_nct_for_primitives() {
+        fn assert_nct<T: HasPersonality<P = Nct>>() {}
+        assert_nct::<u8>();
+        assert_nct::<u32>();
+        assert_nct::<u128>();
+        assert_nct::<usize>();
+        assert_nct::<i64>();
     }
 
     #[test]

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -120,7 +120,9 @@ macro_rules! impl_has_personality_nct {
     };
 }
 
-impl_has_personality_nct!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+impl_has_personality_nct!(
+    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Adds the `HasPersonality { type P: Personality; }` projection alongside `Personality`/`Nct`/`Ct`, with impls for the integer primitives (`P = Nct`).

Motivation: a personality gate otherwise has to name every carrier type it admits, because the orphan rule forces the marker impl into whichever crate owns the marker trait. With a projection, a carrier declares its personality once at its own definition site, and a consumer bounds `T: HasPersonality<P = Nct>` (variable-time paths) or `P = Ct` (constant-time-only paths) without enumerating carriers.

Additive; version bumped to 0.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `HasPersonality` trait so types can expose their associated `Personality` at the type level.
  * Implemented the new trait for primitive integer types with `Nct` as the default personality.
* **Documentation**
  * Added/updated migration and compatibility guides, including an API breaks overview and nightly compiler migration instructions.
  * Added project documentation covering design direction and method/coverage status.
* **Chores**
  * Bumped the crate version to `0.1.1`.
  * Updated the documented nightly minimum to `nightly >= 2026-06-19` for const-enabled features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->