### PR TITLE
Decouple operator supertraits from arithmetic traits (0.2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kaidokert/num-traits"
 name = "const-num-traits"
-version = "0.1.2"
+version = "0.2.0"
 readme = "README.md"
 # Include-list of the files that ship. Anything not listed here is never packaged.
 include = [

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-const-num-traits = "0.1"
+const-num-traits = "0.2"
 ```
 
 Enable the `const trait` surface with the `nightly` feature on a nightly compiler:
 
 ```toml
 [dependencies]
-const-num-traits = { version = "0.1", features = ["nightly"] }
+const-num-traits = { version = "0.2", features = ["nightly"] }
 ```
 
 ## Features
@@ -40,7 +40,7 @@ the default `std` feature. Use this in `Cargo.toml`:
 
 ```toml
 [dependencies.const-num-traits]
-version = "0.1"
+version = "0.2"
 default-features = false
 # features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real` without `std`
 ```

--- a/src/int.rs
+++ b/src/int.rs
@@ -378,7 +378,7 @@ pub c0nst trait PrimInt:
     + [c0nst] CheckedSub<Output = Self>
     + [c0nst] CheckedMul<Output = Self>
     + [c0nst] CheckedDiv<Output = Self>
-    + [c0nst] Saturating
+    + [c0nst] Saturating<Output = Self>
 {
     /// Raises self to the power of `exp`, using exponentiation by squaring.
     ///

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -17,11 +17,11 @@
 //! shift amount); for a secret mask they are Tier C. [`HighestOne`]/[`LowestOne`]
 //! and [`ShlExact`]/[`ShrExact`] are Tier B (`Option` returns).
 
-use core::ops::{Shl, Shr};
-
 c0nst::c0nst! {
 /// Performs a left shift that never panics, returning 0 for large shifts.
-pub c0nst trait UnboundedShl: Sized + [c0nst] Shl<u32> {
+pub c0nst trait UnboundedShl: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Unbounded shift left. Computes `self << rhs`, without bounding the
     /// value of `rhs`: if `rhs >= BITS` the entire value is shifted out and
     /// 0 is returned.
@@ -32,14 +32,16 @@ pub c0nst trait UnboundedShl: Sized + [c0nst] Shl<u32> {
     /// assert_eq!(UnboundedShl::unbounded_shl(1u8, 4), 16);
     /// assert_eq!(UnboundedShl::unbounded_shl(1u8, 200), 0);
     /// ```
-    fn unbounded_shl(self, rhs: u32) -> <Self as Shl<u32>>::Output;
+    fn unbounded_shl(self, rhs: u32) -> Self::Output;
 }
 }
 
 c0nst::c0nst! {
 /// Performs a right shift that never panics, shifting in zero or sign bits
 /// for large shift amounts.
-pub c0nst trait UnboundedShr: Sized + [c0nst] Shr<u32> {
+pub c0nst trait UnboundedShr: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Unbounded shift right. Computes `self >> rhs`, without bounding the
     /// value of `rhs`: if `rhs >= BITS`, unsigned values become 0 and signed
     /// values become 0 or -1 depending on the sign (the sign bit fills every
@@ -52,7 +54,7 @@ pub c0nst trait UnboundedShr: Sized + [c0nst] Shr<u32> {
     /// assert_eq!(UnboundedShr::unbounded_shr(16u8, 200), 0);
     /// assert_eq!(UnboundedShr::unbounded_shr(-16i8, 200), -1);
     /// ```
-    fn unbounded_shr(self, rhs: u32) -> <Self as Shr<u32>>::Output;
+    fn unbounded_shr(self, rhs: u32) -> Self::Output;
 }
 }
 
@@ -60,6 +62,7 @@ macro_rules! unbounded_shift_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl UnboundedShl for $t {
+            type Output = $t;
             #[inline]
             fn unbounded_shl(self, rhs: u32) -> Self {
                 if rhs < <$t>::BITS { self << rhs } else { 0 }
@@ -68,6 +71,7 @@ macro_rules! unbounded_shift_impl {
         }
         c0nst::c0nst! {
         c0nst impl UnboundedShr for $t {
+            type Output = $t;
             #[inline]
             fn unbounded_shr(self, rhs: u32) -> Self {
                 if rhs < <$t>::BITS { self >> rhs } else { 0 }
@@ -78,6 +82,7 @@ macro_rules! unbounded_shift_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl UnboundedShl for $t {
+            type Output = $t;
             #[inline]
             fn unbounded_shl(self, rhs: u32) -> Self {
                 if rhs < <$t>::BITS { self << rhs } else { 0 }
@@ -86,6 +91,7 @@ macro_rules! unbounded_shift_impl {
         }
         c0nst::c0nst! {
         c0nst impl UnboundedShr for $t {
+            type Output = $t;
             #[inline]
             fn unbounded_shr(self, rhs: u32) -> Self {
                 if rhs < <$t>::BITS {
@@ -186,7 +192,9 @@ funnel_shift_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
 /// Performs a lossless (exactly reversible) left shift.
-pub c0nst trait ShlExact: Sized + [c0nst] Shl<u32> {
+pub c0nst trait ShlExact: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Exact shift left. Computes `self << rhs` if no bits would be shifted
     /// out (so the operation can be losslessly reversed), `None` otherwise.
     ///
@@ -196,13 +204,15 @@ pub c0nst trait ShlExact: Sized + [c0nst] Shl<u32> {
     /// assert_eq!(ShlExact::shl_exact(0x11u8, 3), Some(0x88));
     /// assert_eq!(ShlExact::shl_exact(0x11u8, 4), None);
     /// ```
-    fn shl_exact(self, rhs: u32) -> Option<<Self as Shl<u32>>::Output>;
+    fn shl_exact(self, rhs: u32) -> Option<Self::Output>;
 }
 }
 
 c0nst::c0nst! {
 /// Performs a lossless (exactly reversible) right shift.
-pub c0nst trait ShrExact: Sized + [c0nst] Shr<u32> {
+pub c0nst trait ShrExact: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Exact shift right. Computes `self >> rhs` if no one-bits would be
     /// shifted out (so the operation can be losslessly reversed), `None`
     /// otherwise.
@@ -213,7 +223,7 @@ pub c0nst trait ShrExact: Sized + [c0nst] Shr<u32> {
     /// assert_eq!(ShrExact::shr_exact(0x88u8, 3), Some(0x11));
     /// assert_eq!(ShrExact::shr_exact(0x88u8, 4), None);
     /// ```
-    fn shr_exact(self, rhs: u32) -> Option<<Self as Shr<u32>>::Output>;
+    fn shr_exact(self, rhs: u32) -> Option<Self::Output>;
 }
 }
 
@@ -221,6 +231,7 @@ macro_rules! exact_shift_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl ShlExact for $t {
+            type Output = $t;
             #[inline]
             fn shl_exact(self, rhs: u32) -> Option<Self> {
                 if rhs <= <$t>::leading_zeros(self) && rhs < <$t>::BITS {
@@ -236,6 +247,7 @@ macro_rules! exact_shift_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl ShlExact for $t {
+            type Output = $t;
             #[inline]
             fn shl_exact(self, rhs: u32) -> Option<Self> {
                 // for negative values the sign-extension bits are the
@@ -253,6 +265,7 @@ macro_rules! exact_shift_impl {
     (@shr $t:ty) => {
         c0nst::c0nst! {
         c0nst impl ShrExact for $t {
+            type Output = $t;
             #[inline]
             fn shr_exact(self, rhs: u32) -> Option<Self> {
                 if rhs <= <$t>::trailing_zeros(self) && rhs < <$t>::BITS {

--- a/src/ops/carrying.rs
+++ b/src/ops/carrying.rs
@@ -10,8 +10,6 @@
 //! **CT tier A (CT-implementable)**: carries and borrows are returned for
 //! arithmetic consumption; all bodies are branchless on the data.
 
-use core::ops::{Add, Mul, Sub};
-
 #[cfg(target_pointer_width = "16")]
 type UDoubleSize = u32;
 #[cfg(target_pointer_width = "32")]
@@ -28,7 +26,9 @@ type IDoubleSize = i128;
 
 c0nst::c0nst! {
 /// Performs addition with a carry bit, for chaining multi-word additions.
-pub c0nst trait CarryingAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait CarryingAdd: Sized {
+    /// The sum type (`Self` for the primitive impls).
+    type Output;
     /// Calculates `self + rhs + carry` and returns a tuple containing the sum
     /// and the output carry, performing the full addition rather than
     /// stopping at the first overflow.
@@ -44,7 +44,7 @@ pub c0nst trait CarryingAdd: Sized + [c0nst] Add<Self> {
     /// assert_eq!(CarryingAdd::carrying_add(u8::MAX, 1, true), (1, true));
     /// assert_eq!(CarryingAdd::carrying_add(5u8, 2, false), (7, false));
     /// ```
-    fn carrying_add(self, rhs: Self, carry: bool) -> (<Self as Add<Self>>::Output, bool);
+    fn carrying_add(self, rhs: Self, carry: bool) -> (Self::Output, bool);
 }
 }
 
@@ -53,6 +53,7 @@ macro_rules! carrying_add_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl CarryingAdd for $t {
+            type Output = $t;
             #[inline]
             fn carrying_add(self, rhs: Self, carry: bool) -> ($t, bool) {
                 let (a, c1) = <$t>::overflowing_add(self, rhs);
@@ -67,6 +68,7 @@ macro_rules! carrying_add_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl CarryingAdd for $t {
+            type Output = $t;
             #[inline]
             fn carrying_add(self, rhs: Self, carry: bool) -> ($t, bool) {
                 let (a, b) = <$t>::overflowing_add(self, rhs);
@@ -83,7 +85,9 @@ carrying_add_impl!(signed isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Performs subtraction with a borrow bit, for chaining multi-word subtractions.
-pub c0nst trait BorrowingSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait BorrowingSub: Sized {
+    /// The difference type (`Self` for the primitive impls).
+    type Output;
     /// Calculates `self - rhs - borrow` and returns a tuple containing the
     /// difference and the output borrow, performing the full subtraction
     /// rather than stopping at the first overflow.
@@ -98,7 +102,7 @@ pub c0nst trait BorrowingSub: Sized + [c0nst] Sub<Self> {
     /// assert_eq!(BorrowingSub::borrowing_sub(0u8, 0, true), (u8::MAX, true));
     /// assert_eq!(BorrowingSub::borrowing_sub(7u8, 2, false), (5, false));
     /// ```
-    fn borrowing_sub(self, rhs: Self, borrow: bool) -> (<Self as Sub<Self>>::Output, bool);
+    fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self::Output, bool);
 }
 }
 
@@ -106,6 +110,7 @@ macro_rules! borrowing_sub_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl BorrowingSub for $t {
+            type Output = $t;
             #[inline]
             fn borrowing_sub(self, rhs: Self, borrow: bool) -> ($t, bool) {
                 let (a, c1) = <$t>::overflowing_sub(self, rhs);
@@ -118,6 +123,7 @@ macro_rules! borrowing_sub_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl BorrowingSub for $t {
+            type Output = $t;
             #[inline]
             fn borrowing_sub(self, rhs: Self, borrow: bool) -> ($t, bool) {
                 let (a, b) = <$t>::overflowing_sub(self, rhs);
@@ -135,11 +141,14 @@ borrowing_sub_impl!(signed isize i8 i16 i32 i64 i128);
 c0nst::c0nst! {
 /// Performs full double-width multiplication with carry and addend inputs,
 /// the workhorse for multi-word ("bigint") multiplication.
-pub c0nst trait CarryingMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait CarryingMul: Sized {
     /// The type of the low half of the result: `Self` for unsigned types,
     /// the unsigned counterpart for signed types (matching std's
     /// `carrying_mul` signatures).
     type Unsigned;
+
+    /// The type of the high half of the result (`Self` for the primitive impls).
+    type Output;
 
     /// Calculates the "full multiplication" `self * rhs + carry` without the
     /// possibility to overflow, returning `(low, high)` words of the result.
@@ -150,14 +159,14 @@ pub c0nst trait CarryingMul: Sized + [c0nst] Mul<Self> {
     /// assert_eq!(CarryingMul::carrying_mul(u8::MAX, u8::MAX, u8::MAX), (0, u8::MAX));
     /// assert_eq!(CarryingMul::carrying_mul(5u8, 7, 3), (38, 0));
     /// ```
-    fn carrying_mul(self, rhs: Self, carry: Self) -> (Self::Unsigned, <Self as Mul<Self>>::Output);
+    fn carrying_mul(self, rhs: Self, carry: Self) -> (Self::Unsigned, Self::Output);
 
     /// Calculates the "full multiplication" `self * rhs + carry + add`
     /// without the possibility to overflow, returning `(low, high)` words.
     ///
     /// This cannot overflow because `MAX * MAX + MAX + MAX` still fits in
     /// twice the bit width.
-    fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, <Self as Mul<Self>>::Output);
+    fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output);
 }
 }
 
@@ -168,6 +177,7 @@ macro_rules! carrying_mul_impl {
         c0nst::c0nst! {
         c0nst impl CarryingMul for $t {
             type Unsigned = $u;
+            type Output = $t;
 
             #[inline]
             fn carrying_mul(self, rhs: Self, carry: Self) -> ($u, $t) {
@@ -228,6 +238,7 @@ pub(crate) const fn wide_mul_u128(a: u128, b: u128) -> (u128, u128) {
 c0nst::c0nst! {
 c0nst impl CarryingMul for u128 {
     type Unsigned = u128;
+    type Output = u128;
 
     #[inline]
     fn carrying_mul(self, rhs: Self, carry: Self) -> (u128, u128) {
@@ -252,6 +263,7 @@ c0nst impl CarryingMul for u128 {
 c0nst::c0nst! {
 c0nst impl CarryingMul for i128 {
     type Unsigned = u128;
+    type Output = i128;
 
     #[inline]
     fn carrying_mul(self, rhs: Self, carry: Self) -> (u128, i128) {
@@ -279,7 +291,7 @@ c0nst impl CarryingMul for i128 {
 c0nst::c0nst! {
 /// Performs multiplication that widens into the next-larger integer type, so
 /// it cannot overflow.
-pub c0nst trait WideningMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait WideningMul: Sized {
     /// The double-width result type.
     type Wide;
 

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -6,14 +6,15 @@
 //! (cargo feature `ct`). `CheckedDiv`/`CheckedRem` are CT-hostile (data-dependent
 //! division) and `CheckedPow` is exponent-dependent — Tier C for secret inputs.
 
-use core::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-
 c0nst::c0nst! {
 /// Performs addition, returning `None` if overflow occurred.
-pub c0nst trait CheckedAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait CheckedAdd: Sized {
+    /// The result type. `Self` for the primitive impls; a distinct owned type
+    /// lets non-`Copy` types implement this via `impl for &Self`.
+    type Output;
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
-    fn checked_add(self, v: Self) -> Option<<Self as Add<Self>>::Output>;
+    fn checked_add(self, v: Self) -> Option<Self::Output>;
 }
 }
 
@@ -21,6 +22,7 @@ macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, v: $t) -> Option<$t> {
                 <$t>::$method(self, v)
@@ -46,10 +48,12 @@ checked_impl!(CheckedAdd, checked_add, i128);
 
 c0nst::c0nst! {
 /// Performs subtraction, returning `None` if overflow occurred.
-pub c0nst trait CheckedSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait CheckedSub: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Subtracts two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
-    fn checked_sub(self, v: Self) -> Option<<Self as Sub<Self>>::Output>;
+    fn checked_sub(self, v: Self) -> Option<Self::Output>;
 }
 }
 
@@ -69,10 +73,12 @@ checked_impl!(CheckedSub, checked_sub, i128);
 
 c0nst::c0nst! {
 /// Performs multiplication, returning `None` if overflow occurred.
-pub c0nst trait CheckedMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait CheckedMul: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
-    fn checked_mul(self, v: Self) -> Option<<Self as Mul<Self>>::Output>;
+    fn checked_mul(self, v: Self) -> Option<Self::Output>;
 }
 }
 
@@ -93,10 +99,12 @@ checked_impl!(CheckedMul, checked_mul, i128);
 c0nst::c0nst! {
 /// Performs division, returning `None` on division by zero or if overflow
 /// occurred.
-pub c0nst trait CheckedDiv: Sized + [c0nst] Div<Self> {
+pub c0nst trait CheckedDiv: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Divides two numbers, checking for overflow and division by
     /// zero. If any of that happens, `None` is returned.
-    fn checked_div(self, v: Self) -> Option<<Self as Div<Self>>::Output>;
+    fn checked_div(self, v: Self) -> Option<Self::Output>;
 }
 }
 
@@ -117,7 +125,9 @@ checked_impl!(CheckedDiv, checked_div, i128);
 c0nst::c0nst! {
 /// Performs integral remainder, returning `None` on division by zero or if
 /// overflow occurred.
-pub c0nst trait CheckedRem: Sized + [c0nst] Rem<Self> {
+pub c0nst trait CheckedRem: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Finds the remainder of dividing two numbers, checking for overflow and
     /// division by zero. If any of that happens, `None` is returned.
     ///
@@ -137,7 +147,7 @@ pub c0nst trait CheckedRem: Sized + [c0nst] Rem<Self> {
     /// assert_eq!(CheckedRem::checked_rem(MIN, 1), Some(0));
     /// assert_eq!(CheckedRem::checked_rem(MIN, -1), None);
     /// ```
-    fn checked_rem(self, v: Self) -> Option<<Self as Rem<Self>>::Output>;
+    fn checked_rem(self, v: Self) -> Option<Self::Output>;
 }
 }
 
@@ -159,6 +169,7 @@ macro_rules! checked_impl_unary {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self) -> Option<$t> {
                 <$t>::$method(self)
@@ -214,7 +225,9 @@ checked_neg_impl!(u8 u16 u32 u64 usize u128 i8 i16 i32 i64 isize i128);
 c0nst::c0nst! {
 /// Performs shift left, returning `None` on shifts larger than or equal to
 /// the type width.
-pub c0nst trait CheckedShl: Sized + [c0nst] Shl<u32> {
+pub c0nst trait CheckedShl: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Checked shift left. Computes `self << rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
@@ -228,7 +241,7 @@ pub c0nst trait CheckedShl: Sized + [c0nst] Shl<u32> {
     /// assert_eq!(CheckedShl::checked_shl(x, 15), Some(0x8000));
     /// assert_eq!(CheckedShl::checked_shl(x, 16), None);
     /// ```
-    fn checked_shl(self, rhs: u32) -> Option<<Self as Shl<u32>>::Output>;
+    fn checked_shl(self, rhs: u32) -> Option<Self::Output>;
 }
 }
 
@@ -236,6 +249,7 @@ macro_rules! checked_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, rhs: u32) -> Option<$t> {
                 <$t>::$method(self, rhs)
@@ -262,7 +276,9 @@ checked_shift_impl!(CheckedShl, checked_shl, i128);
 c0nst::c0nst! {
 /// Performs shift right, returning `None` on shifts larger than or equal to
 /// the type width.
-pub c0nst trait CheckedShr: Sized + [c0nst] Shr<u32> {
+pub c0nst trait CheckedShr: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Checked shift right. Computes `self >> rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
@@ -276,7 +292,7 @@ pub c0nst trait CheckedShr: Sized + [c0nst] Shr<u32> {
     /// assert_eq!(CheckedShr::checked_shr(x, 15), Some(0x0001));
     /// assert_eq!(CheckedShr::checked_shr(x, 16), None);
     /// ```
-    fn checked_shr(self, rhs: u32) -> Option<<Self as Shr<u32>>::Output>;
+    fn checked_shr(self, rhs: u32) -> Option<Self::Output>;
 }
 }
 
@@ -296,7 +312,9 @@ checked_shift_impl!(CheckedShr, checked_shr, i128);
 
 c0nst::c0nst! {
 /// Computes the absolute value, returning `None` if it can't be represented.
-pub c0nst trait CheckedAbs: Sized + [c0nst] Neg {
+pub c0nst trait CheckedAbs: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Checked absolute value. Computes `self.abs()`, returning `None` if
     /// `self == MIN` (the result can't be represented).
     ///
@@ -308,7 +326,7 @@ pub c0nst trait CheckedAbs: Sized + [c0nst] Neg {
     /// assert_eq!(CheckedAbs::checked_abs(-5i32), Some(5));
     /// assert_eq!(CheckedAbs::checked_abs(i32::MIN), None);
     /// ```
-    fn checked_abs(self) -> Option<<Self as Neg>::Output>;
+    fn checked_abs(self) -> Option<Self::Output>;
 }
 }
 
@@ -321,7 +339,9 @@ checked_impl_unary!(CheckedAbs, checked_abs, i128);
 
 c0nst::c0nst! {
 /// Performs exponentiation, returning `None` if overflow occurred.
-pub c0nst trait CheckedPow: Sized + [c0nst] Mul<Self> {
+pub c0nst trait CheckedPow: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Checked exponentiation. Computes `self.pow(exp)`, returning `None` if
     /// overflow occurred.
     ///
@@ -337,7 +357,7 @@ pub c0nst trait CheckedPow: Sized + [c0nst] Mul<Self> {
     /// assert_eq!(CheckedPow::checked_pow(7i8, 8), None);
     /// assert_eq!(CheckedPow::checked_pow(0u32, 0), Some(1));
     /// ```
-    fn checked_pow(self, exp: u32) -> Option<<Self as Mul<Self>>::Output>;
+    fn checked_pow(self, exp: u32) -> Option<Self::Output>;
 }
 }
 
@@ -357,10 +377,10 @@ checked_shift_impl!(CheckedPow, checked_pow, i128);
 
 #[test]
 fn test_checked_abs_pow() {
-    fn checked_abs<T: CheckedAbs + core::ops::Neg<Output = T>>(a: T) -> Option<T> {
+    fn checked_abs<T: CheckedAbs<Output = T>>(a: T) -> Option<T> {
         a.checked_abs()
     }
-    fn checked_pow<T: CheckedPow + core::ops::Mul<Output = T>>(a: T, exp: u32) -> Option<T> {
+    fn checked_pow<T: CheckedPow<Output = T>>(a: T, exp: u32) -> Option<T> {
         a.checked_pow(exp)
     }
     assert_eq!(checked_abs(-5i16), Some(5));

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -3,10 +3,12 @@
 //! **CT tier C (CT-hostile)**: division is data-dependent on every
 //! mainstream CPU; constant-time types should not implement these.
 
-use core::ops::{Div, Rem};
-
 c0nst::c0nst! {
-pub c0nst trait Euclid: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
+pub c0nst trait Euclid: Sized {
+    /// The result type of Euclidean division and remainder (`Self` for the
+    /// primitive and float impls).
+    type Output;
+
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
     ///
     /// This computes the integer `n` such that
@@ -26,7 +28,7 @@ pub c0nst trait Euclid: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
     /// assert_eq!(Euclid::div_euclid(a, -b), -1); // 7 >= -4 * -1
     /// assert_eq!(Euclid::div_euclid(-a, -b), 2); // -7 >= -4 * 2
     /// ```
-    fn div_euclid(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn div_euclid(self, v: Self) -> Self::Output;
 
     /// Calculates the least nonnegative remainder of `self (mod v)`.
     ///
@@ -51,7 +53,7 @@ pub c0nst trait Euclid: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
     /// assert_eq!(Euclid::rem_euclid(a, -b), 3);
     /// assert_eq!(Euclid::rem_euclid(-a, -b), 1);
     /// ```
-    fn rem_euclid(self, v: Self) -> <Self as Rem<Self>>::Output;
+    fn rem_euclid(self, v: Self) -> Self::Output;
 
     /// Returns both the quotient and remainder from Euclidean division.
     ///
@@ -70,7 +72,7 @@ pub c0nst trait Euclid: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
     ///
     /// assert_eq!((div, rem), Euclid::div_rem_euclid(x, y));
     /// ```
-    fn div_rem_euclid(self, v: Self) -> (<Self as Div<Self>>::Output, <Self as Rem<Self>>::Output);
+    fn div_rem_euclid(self, v: Self) -> (Self::Output, Self::Output);
 }
 }
 
@@ -78,6 +80,7 @@ macro_rules! euclid_forward_impl {
     ($($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl Euclid for $t {
+            type Output = $t;
             #[inline]
             fn div_euclid(self, v: $t) -> Self {
                 <$t>::div_euclid(self, v)
@@ -106,6 +109,7 @@ euclid_forward_impl!(usize u8 u16 u32 u64 u128);
 macro_rules! euclid_forward_impl_float {
     ($($t:ty)*) => {$(
         impl Euclid for $t {
+            type Output = $t;
             #[inline]
             fn div_euclid(self, v: $t) -> Self {
                 <$t>::div_euclid(self, v)
@@ -129,6 +133,7 @@ euclid_forward_impl_float!(f32 f64);
 
 #[cfg(not(feature = "std"))]
 impl Euclid for f32 {
+    type Output = f32;
     #[inline]
     fn div_euclid(self, v: f32) -> f32 {
         let q = <f32 as crate::float::FloatCore>::trunc(self / v);
@@ -156,6 +161,7 @@ impl Euclid for f32 {
 
 #[cfg(not(feature = "std"))]
 impl Euclid for f64 {
+    type Output = f64;
     #[inline]
     fn div_euclid(self, v: f64) -> f64 {
         let q = <f64 as crate::float::FloatCore>::trunc(self / v);
@@ -185,11 +191,11 @@ c0nst::c0nst! {
 pub c0nst trait CheckedEuclid: [c0nst] Euclid {
     /// Performs euclid division, returning `None` on division by zero or if
     /// overflow occurred.
-    fn checked_div_euclid(self, v: Self) -> Option<<Self as Div<Self>>::Output>;
+    fn checked_div_euclid(self, v: Self) -> Option<<Self as Euclid>::Output>;
 
     /// Finds the euclid remainder of dividing two numbers, returning `None` on
     /// division by zero or if overflow occurred.
-    fn checked_rem_euclid(self, v: Self) -> Option<<Self as Rem<Self>>::Output>;
+    fn checked_rem_euclid(self, v: Self) -> Option<<Self as Euclid>::Output>;
 
     /// Returns both the quotient and remainder from checked Euclidean division,
     /// returning `None` on division by zero or if overflow occurred.
@@ -206,7 +212,7 @@ pub c0nst trait CheckedEuclid: [c0nst] Euclid {
     ///
     /// assert_eq!(Some((div.unwrap(), rem.unwrap())), CheckedEuclid::checked_div_rem_euclid(x, y));
     /// ```
-    fn checked_div_rem_euclid(self, v: Self) -> Option<(<Self as Div<Self>>::Output, <Self as Rem<Self>>::Output)>;
+    fn checked_div_rem_euclid(self, v: Self) -> Option<(<Self as Euclid>::Output, <Self as Euclid>::Output)>;
 }
 }
 
@@ -256,7 +262,7 @@ pub c0nst trait WrappingEuclid: [c0nst] Euclid {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn wrapping_div_euclid(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn wrapping_div_euclid(self, v: Self) -> <Self as Euclid>::Output;
 
     /// Wrapping Euclidean remainder. Computes `Euclid::rem_euclid(self, v)`,
     /// wrapping around at the boundary of the type. The only wrapping case is
@@ -265,7 +271,7 @@ pub c0nst trait WrappingEuclid: [c0nst] Euclid {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn wrapping_rem_euclid(self, v: Self) -> <Self as Rem<Self>>::Output;
+    fn wrapping_rem_euclid(self, v: Self) -> <Self as Euclid>::Output;
 }
 }
 
@@ -300,7 +306,7 @@ pub c0nst trait OverflowingEuclid: [c0nst] Euclid {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn overflowing_div_euclid(self, v: Self) -> (<Self as Div<Self>>::Output, bool);
+    fn overflowing_div_euclid(self, v: Self) -> (<Self as Euclid>::Output, bool);
 
     /// Returns a tuple of the Euclidean remainder along with a boolean
     /// indicating whether an arithmetic overflow would occur. The only
@@ -310,7 +316,7 @@ pub c0nst trait OverflowingEuclid: [c0nst] Euclid {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn overflowing_rem_euclid(self, v: Self) -> (<Self as Rem<Self>>::Output, bool);
+    fn overflowing_rem_euclid(self, v: Self) -> (<Self as Euclid>::Output, bool);
 }
 }
 

--- a/src/ops/overflowing.rs
+++ b/src/ops/overflowing.rs
@@ -6,12 +6,11 @@
 //! code. `OverflowingDiv`/`OverflowingRem` are CT-hostile (data-dependent
 //! division) and `OverflowingPow` is exponent-dependent — Tier C for secrets.
 
-use core::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-
 macro_rules! overflowing_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, v: Self) -> (Self, bool) {
                 <$t>::$method(self, v)
@@ -23,10 +22,12 @@ macro_rules! overflowing_impl {
 
 c0nst::c0nst! {
 /// Performs addition with a flag for overflow.
-pub c0nst trait OverflowingAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait OverflowingAdd: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the sum along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_add(self, v: Self) -> (<Self as Add<Self>>::Output, bool);
+    fn overflowing_add(self, v: Self) -> (Self::Output, bool);
 }
 }
 
@@ -46,10 +47,12 @@ overflowing_impl!(OverflowingAdd, overflowing_add, i128);
 
 c0nst::c0nst! {
 /// Performs substraction with a flag for overflow.
-pub c0nst trait OverflowingSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait OverflowingSub: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the difference along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_sub(self, v: Self) -> (<Self as Sub<Self>>::Output, bool);
+    fn overflowing_sub(self, v: Self) -> (Self::Output, bool);
 }
 }
 
@@ -69,10 +72,12 @@ overflowing_impl!(OverflowingSub, overflowing_sub, i128);
 
 c0nst::c0nst! {
 /// Performs multiplication with a flag for overflow.
-pub c0nst trait OverflowingMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait OverflowingMul: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the product along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_mul(self, v: Self) -> (<Self as Mul<Self>>::Output, bool);
+    fn overflowing_mul(self, v: Self) -> (Self::Output, bool);
 }
 }
 
@@ -92,7 +97,9 @@ overflowing_impl!(OverflowingMul, overflowing_mul, i128);
 
 c0nst::c0nst! {
 /// Performs division with a flag for overflow.
-pub c0nst trait OverflowingDiv: Sized + [c0nst] Div<Self> {
+pub c0nst trait OverflowingDiv: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the quotient along with a boolean indicating whether
     /// an arithmetic overflow would occur. The only overflowing case is
     /// `MIN / -1` on a signed type, where the wrapped value is returned.
@@ -100,7 +107,7 @@ pub c0nst trait OverflowingDiv: Sized + [c0nst] Div<Self> {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn overflowing_div(self, v: Self) -> (<Self as Div<Self>>::Output, bool);
+    fn overflowing_div(self, v: Self) -> (Self::Output, bool);
 }
 }
 
@@ -120,7 +127,9 @@ overflowing_impl!(OverflowingDiv, overflowing_div, i128);
 
 c0nst::c0nst! {
 /// Performs a remainder operation with a flag for overflow.
-pub c0nst trait OverflowingRem: Sized + [c0nst] Rem<Self> {
+pub c0nst trait OverflowingRem: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the remainder along with a boolean indicating
     /// whether an arithmetic overflow would occur. The only overflowing case
     /// is `MIN % -1` on a signed type, where the remainder is 0.
@@ -128,7 +137,7 @@ pub c0nst trait OverflowingRem: Sized + [c0nst] Rem<Self> {
     /// # Panics
     ///
     /// Panics if `v` is zero.
-    fn overflowing_rem(self, v: Self) -> (<Self as Rem<Self>>::Output, bool);
+    fn overflowing_rem(self, v: Self) -> (Self::Output, bool);
 }
 }
 
@@ -162,6 +171,7 @@ macro_rules! overflowing_unary_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self) -> ($t, bool) {
                 <$t>::$method(self)
@@ -186,11 +196,13 @@ overflowing_neg_impl!(u8 u16 u32 u64 usize u128 i8 i16 i32 i64 isize i128);
 
 c0nst::c0nst! {
 /// Computes the absolute value with a flag for overflow.
-pub c0nst trait OverflowingAbs: Sized + [c0nst] Neg {
+pub c0nst trait OverflowingAbs: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Returns a tuple of the absolute value along with a boolean indicating
     /// whether an arithmetic overflow would occur. The only overflowing case
     /// is `MIN.overflowing_abs()` which returns `(MIN, true)`.
-    fn overflowing_abs(self) -> (<Self as Neg>::Output, bool);
+    fn overflowing_abs(self) -> (Self::Output, bool);
 }
 }
 
@@ -205,6 +217,7 @@ macro_rules! overflowing_u32_rhs_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, rhs: u32) -> ($t, bool) {
                 <$t>::$method(self, rhs)
@@ -216,7 +229,9 @@ macro_rules! overflowing_u32_rhs_impl {
 
 c0nst::c0nst! {
 /// Performs a left shift with a flag for overflow.
-pub c0nst trait OverflowingShl: Sized + [c0nst] Shl<u32> {
+pub c0nst trait OverflowingShl: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Shifts `self` left by a `rhs` masked to the bit width of the type, and
     /// returns a boolean indicating whether `rhs` was larger than or equal to
     /// the number of bits.
@@ -227,7 +242,7 @@ pub c0nst trait OverflowingShl: Sized + [c0nst] Shl<u32> {
     /// assert_eq!(OverflowingShl::overflowing_shl(0x1u16, 4), (0x10, false));
     /// assert_eq!(OverflowingShl::overflowing_shl(0x1u16, 20), (0x10, true));
     /// ```
-    fn overflowing_shl(self, rhs: u32) -> (<Self as Shl<u32>>::Output, bool);
+    fn overflowing_shl(self, rhs: u32) -> (Self::Output, bool);
 }
 }
 
@@ -247,7 +262,9 @@ overflowing_u32_rhs_impl!(OverflowingShl, overflowing_shl, i128);
 
 c0nst::c0nst! {
 /// Performs a right shift with a flag for overflow.
-pub c0nst trait OverflowingShr: Sized + [c0nst] Shr<u32> {
+pub c0nst trait OverflowingShr: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Shifts `self` right by a `rhs` masked to the bit width of the type, and
     /// returns a boolean indicating whether `rhs` was larger than or equal to
     /// the number of bits.
@@ -258,7 +275,7 @@ pub c0nst trait OverflowingShr: Sized + [c0nst] Shr<u32> {
     /// assert_eq!(OverflowingShr::overflowing_shr(0x10u16, 4), (0x1, false));
     /// assert_eq!(OverflowingShr::overflowing_shr(0x10u16, 20), (0x1, true));
     /// ```
-    fn overflowing_shr(self, rhs: u32) -> (<Self as Shr<u32>>::Output, bool);
+    fn overflowing_shr(self, rhs: u32) -> (Self::Output, bool);
 }
 }
 
@@ -278,11 +295,13 @@ overflowing_u32_rhs_impl!(OverflowingShr, overflowing_shr, i128);
 
 c0nst::c0nst! {
 /// Performs exponentiation with a flag for overflow.
-pub c0nst trait OverflowingPow: Sized + [c0nst] Mul<Self> {
+pub c0nst trait OverflowingPow: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Raises `self` to the power of `exp`, returning a tuple of the
     /// (possibly wrapped) result and a boolean indicating whether an
     /// arithmetic overflow occurred.
-    fn overflowing_pow(self, exp: u32) -> (<Self as Mul<Self>>::Output, bool);
+    fn overflowing_pow(self, exp: u32) -> (Self::Output, bool);
 }
 }
 

--- a/src/ops/rounding.rs
+++ b/src/ops/rounding.rs
@@ -12,11 +12,11 @@
 //! **CT tiers**: [`Midpoint`] is Tier A (branchless); everything else here
 //! is Tier C (division-based).
 
-use core::ops::{Add, Div, Rem};
-
 c0nst::c0nst! {
 /// Performs division, rounding the quotient towards positive infinity.
-pub c0nst trait DivCeil: Sized + [c0nst] Div<Self> {
+pub c0nst trait DivCeil: Sized {
+    /// The quotient type (`Self` for the primitive impls).
+    type Output;
     /// Calculates the quotient of `self` and `rhs`, rounding the result
     /// towards positive infinity.
     ///
@@ -32,7 +32,7 @@ pub c0nst trait DivCeil: Sized + [c0nst] Div<Self> {
     /// assert_eq!(DivCeil::div_ceil(7i8, -2), -3);
     /// assert_eq!(DivCeil::div_ceil(-7i8, 2), -3);
     /// ```
-    fn div_ceil(self, rhs: Self) -> <Self as Div<Self>>::Output;
+    fn div_ceil(self, rhs: Self) -> Self::Output;
 }
 }
 
@@ -40,6 +40,7 @@ macro_rules! div_ceil_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl DivCeil for $t {
+            type Output = $t;
             #[inline]
             fn div_ceil(self, rhs: Self) -> Self {
                 <$t>::div_ceil(self, rhs)
@@ -51,6 +52,7 @@ macro_rules! div_ceil_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl DivCeil for $t {
+            type Output = $t;
             #[inline]
             fn div_ceil(self, rhs: Self) -> Self {
                 let d = self / rhs;
@@ -74,7 +76,9 @@ div_ceil_impl!(signed isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Performs division, rounding the quotient towards negative infinity.
-pub c0nst trait DivFloor: Sized + [c0nst] Div<Self> {
+pub c0nst trait DivFloor: Sized {
+    /// The quotient type (`Self` for the primitive impls).
+    type Output;
     /// Calculates the quotient of `self` and `rhs`, rounding the result
     /// towards negative infinity. For unsigned types this is the normal
     /// integer division.
@@ -91,7 +95,7 @@ pub c0nst trait DivFloor: Sized + [c0nst] Div<Self> {
     /// assert_eq!(DivFloor::div_floor(7i8, -2), -4);
     /// assert_eq!(DivFloor::div_floor(-7i8, 2), -4);
     /// ```
-    fn div_floor(self, rhs: Self) -> <Self as Div<Self>>::Output;
+    fn div_floor(self, rhs: Self) -> Self::Output;
 }
 }
 
@@ -100,6 +104,7 @@ macro_rules! div_floor_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl DivFloor for $t {
+            type Output = $t;
             #[inline]
             fn div_floor(self, rhs: Self) -> Self {
                 self / rhs
@@ -110,6 +115,7 @@ macro_rules! div_floor_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl DivFloor for $t {
+            type Output = $t;
             #[inline]
             fn div_floor(self, rhs: Self) -> Self {
                 let d = self / rhs;
@@ -132,7 +138,9 @@ div_floor_impl!(signed isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Performs division without remainder.
-pub c0nst trait DivExact: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
+pub c0nst trait DivExact: Sized {
+    /// The quotient type (`Self` for the primitive impls).
+    type Output;
     /// Integer division without remainder. Computes `self / rhs`, returning
     /// `None` if `self % rhs != 0`.
     ///
@@ -147,12 +155,12 @@ pub c0nst trait DivExact: Sized + [c0nst] Div<Self> + [c0nst] Rem<Self> {
     /// assert_eq!(DivExact::div_exact(64u8, 2), Some(32));
     /// assert_eq!(DivExact::div_exact(65u8, 2), None);
     /// ```
-    fn div_exact(self, rhs: Self) -> Option<<Self as Div<Self>>::Output>;
+    fn div_exact(self, rhs: Self) -> Option<Self::Output>;
 
     /// Checked integer division without remainder. Computes `self / rhs`,
     /// returning `None` if `rhs == 0`, `self % rhs != 0`, or the division
     /// overflowed (`MIN / -1` on a signed type).
-    fn checked_div_exact(self, rhs: Self) -> Option<<Self as Div<Self>>::Output>;
+    fn checked_div_exact(self, rhs: Self) -> Option<Self::Output>;
 }
 }
 
@@ -160,6 +168,7 @@ macro_rules! div_exact_impl {
     ($($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl DivExact for $t {
+            type Output = $t;
             #[inline]
             fn div_exact(self, rhs: Self) -> Option<Self> {
                 if self % rhs != 0 {
@@ -195,7 +204,7 @@ div_exact_impl!(isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Checks divisibility, mirroring `is_multiple_of` on the unsigned primitives.
-pub c0nst trait MultipleOf: Sized + [c0nst] Rem<Self> {
+pub c0nst trait MultipleOf: Sized {
     /// Returns `true` if `self` is an integer multiple of `rhs`, and `false`
     /// otherwise.
     ///
@@ -237,7 +246,9 @@ multiple_of_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
 /// Rounds up to the nearest multiple of a value.
-pub c0nst trait NextMultipleOf: Sized + [c0nst] Add<Self> + [c0nst] Rem<Self> {
+pub c0nst trait NextMultipleOf: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Calculates the smallest value greater than or equal to `self` that is
     /// a multiple of `rhs` (for negative `rhs` on signed types: the closest
     /// to negative infinity).
@@ -254,12 +265,12 @@ pub c0nst trait NextMultipleOf: Sized + [c0nst] Add<Self> + [c0nst] Rem<Self> {
     /// assert_eq!(NextMultipleOf::next_multiple_of(23u8, 8), 24);
     /// assert_eq!(NextMultipleOf::next_multiple_of(-16i8, -5), -20);
     /// ```
-    fn next_multiple_of(self, rhs: Self) -> <Self as Add<Self>>::Output;
+    fn next_multiple_of(self, rhs: Self) -> Self::Output;
 
     /// Calculates the smallest value greater than or equal to `self` that is
     /// a multiple of `rhs`, returning `None` if `rhs` is zero or the
     /// operation would result in overflow.
-    fn checked_next_multiple_of(self, rhs: Self) -> Option<<Self as Add<Self>>::Output>;
+    fn checked_next_multiple_of(self, rhs: Self) -> Option<Self::Output>;
 }
 }
 
@@ -267,6 +278,7 @@ macro_rules! next_multiple_of_impl {
     (unsigned $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl NextMultipleOf for $t {
+            type Output = $t;
             #[inline]
             fn next_multiple_of(self, rhs: Self) -> Self {
                 <$t>::next_multiple_of(self, rhs)
@@ -283,6 +295,7 @@ macro_rules! next_multiple_of_impl {
     (signed $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl NextMultipleOf for $t {
+            type Output = $t;
             #[inline]
             fn next_multiple_of(self, rhs: Self) -> Self {
                 // rhs == -1 would otherwise fail computing `MIN % -1`

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -5,19 +5,19 @@
 //! `SaturatingDiv` is CT-hostile — it performs data-dependent division and
 //! panics on a zero divisor — so it is Tier C for secret inputs.
 
-use core::ops::{Add, Div, Mul, Neg, Sub};
-
 c0nst::c0nst! {
 /// Saturating math operations. Deprecated, use `SaturatingAdd`, `SaturatingSub` and
 /// `SaturatingMul` instead.
 pub c0nst trait Saturating {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating addition operator.
     /// Returns a+b, saturating at the numeric bounds instead of overflowing.
-    fn saturating_add(self, v: Self) -> Self;
+    fn saturating_add(self, v: Self) -> Self::Output;
 
     /// Saturating subtraction operator.
     /// Returns a-b, saturating at the numeric bounds instead of overflowing.
-    fn saturating_sub(self, v: Self) -> Self;
+    fn saturating_sub(self, v: Self) -> Self::Output;
 }
 }
 
@@ -25,6 +25,7 @@ macro_rules! deprecated_saturating_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn saturating_add(self, v: Self) -> Self {
                 Self::saturating_add(self, v)
@@ -46,6 +47,7 @@ macro_rules! saturating_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, v: Self) -> Self {
                 <$t>::$method(self, v)
@@ -57,10 +59,12 @@ macro_rules! saturating_impl {
 
 c0nst::c0nst! {
 /// Performs addition that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait SaturatingAdd: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_add(self, v: Self) -> <Self as Add<Self>>::Output;
+    fn saturating_add(self, v: Self) -> Self::Output;
 }
 }
 
@@ -80,10 +84,12 @@ saturating_impl!(SaturatingAdd, saturating_add, i128);
 
 c0nst::c0nst! {
 /// Performs subtraction that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait SaturatingSub: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating subtraction. Computes `self - other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_sub(self, v: Self) -> <Self as Sub<Self>>::Output;
+    fn saturating_sub(self, v: Self) -> Self::Output;
 }
 }
 
@@ -103,10 +109,12 @@ saturating_impl!(SaturatingSub, saturating_sub, i128);
 
 c0nst::c0nst! {
 /// Performs multiplication that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait SaturatingMul: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_mul(self, v: Self) -> <Self as Mul<Self>>::Output;
+    fn saturating_mul(self, v: Self) -> Self::Output;
 }
 }
 
@@ -126,7 +134,9 @@ saturating_impl!(SaturatingMul, saturating_mul, i128);
 
 c0nst::c0nst! {
 /// Performs division that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingDiv: Sized + [c0nst] Div<Self> {
+pub c0nst trait SaturatingDiv: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating division. Computes `self / other`, saturating at the
     /// relevant high or low boundary of the type. The only saturating case is
     /// `MIN / -1` on a signed type, which saturates to `MAX`.
@@ -141,7 +151,7 @@ pub c0nst trait SaturatingDiv: Sized + [c0nst] Div<Self> {
     /// assert_eq!(SaturatingDiv::saturating_div(5i32, 2), 2);
     /// assert_eq!(SaturatingDiv::saturating_div(i32::MIN, -1), i32::MAX);
     /// ```
-    fn saturating_div(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn saturating_div(self, v: Self) -> Self::Output;
 }
 }
 
@@ -163,6 +173,7 @@ macro_rules! saturating_unary_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self) -> $t {
                 <$t>::$method(self)
@@ -174,7 +185,9 @@ macro_rules! saturating_unary_impl {
 
 c0nst::c0nst! {
 /// Performs negation that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingNeg: Sized + [c0nst] Neg {
+pub c0nst trait SaturatingNeg: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating negation. Computes `-self`, saturating at the numeric
     /// bounds: `MIN.saturating_neg()` is `MAX`.
     ///
@@ -184,7 +197,7 @@ pub c0nst trait SaturatingNeg: Sized + [c0nst] Neg {
     /// assert_eq!(SaturatingNeg::saturating_neg(-5i32), 5);
     /// assert_eq!(SaturatingNeg::saturating_neg(i32::MIN), i32::MAX);
     /// ```
-    fn saturating_neg(self) -> <Self as Neg>::Output;
+    fn saturating_neg(self) -> Self::Output;
 }
 }
 
@@ -197,7 +210,9 @@ saturating_unary_impl!(SaturatingNeg, saturating_neg, i128);
 
 c0nst::c0nst! {
 /// Computes the absolute value, saturating at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingAbs: Sized + [c0nst] Neg {
+pub c0nst trait SaturatingAbs: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating absolute value. Computes `self.abs()`, saturating at the
     /// numeric bounds: `MIN.saturating_abs()` is `MAX`.
     ///
@@ -207,7 +222,7 @@ pub c0nst trait SaturatingAbs: Sized + [c0nst] Neg {
     /// assert_eq!(SaturatingAbs::saturating_abs(-5i32), 5);
     /// assert_eq!(SaturatingAbs::saturating_abs(i32::MIN), i32::MAX);
     /// ```
-    fn saturating_abs(self) -> <Self as Neg>::Output;
+    fn saturating_abs(self) -> Self::Output;
 }
 }
 
@@ -222,6 +237,7 @@ macro_rules! saturating_pow_impl {
     ($t:ty) => {
         c0nst::c0nst! {
         c0nst impl SaturatingPow for $t {
+            type Output = $t;
             #[inline]
             fn saturating_pow(self, exp: u32) -> $t {
                 <$t>::saturating_pow(self, exp)
@@ -233,7 +249,9 @@ macro_rules! saturating_pow_impl {
 
 c0nst::c0nst! {
 /// Performs exponentiation that saturates at the numeric bounds instead of overflowing.
-pub c0nst trait SaturatingPow: Sized + [c0nst] Mul<Self> {
+pub c0nst trait SaturatingPow: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Saturating exponentiation. Computes `self.pow(exp)`, saturating at the
     /// relevant high or low boundary of the type.
     ///
@@ -244,7 +262,7 @@ pub c0nst trait SaturatingPow: Sized + [c0nst] Mul<Self> {
     /// assert_eq!(SaturatingPow::saturating_pow(4u8, 4), u8::MAX);
     /// assert_eq!(SaturatingPow::saturating_pow(-2i8, 7), i8::MIN);
     /// ```
-    fn saturating_pow(self, exp: u32) -> <Self as Mul<Self>>::Output;
+    fn saturating_pow(self, exp: u32) -> Self::Output;
 }
 }
 

--- a/src/ops/strict.rs
+++ b/src/ops/strict.rs
@@ -9,13 +9,13 @@
 //! **CT tier C (CT-hostile)**: panicking on overflow is data-dependent
 //! control flow by definition.
 
-use core::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-
 use super::euclid::Euclid;
 
 c0nst::c0nst! {
 /// Performs addition that panics on overflow, even in release builds.
-pub c0nst trait StrictAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait StrictAdd: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict addition. Computes `self + v`, panicking on overflow regardless
     /// of whether overflow checks are enabled.
     ///
@@ -24,25 +24,29 @@ pub c0nst trait StrictAdd: Sized + [c0nst] Add<Self> {
     ///
     /// assert_eq!(StrictAdd::strict_add(5u8, 250), 255);
     /// ```
-    fn strict_add(self, v: Self) -> <Self as Add<Self>>::Output;
+    fn strict_add(self, v: Self) -> Self::Output;
 }
 }
 
 c0nst::c0nst! {
 /// Performs subtraction that panics on overflow, even in release builds.
-pub c0nst trait StrictSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait StrictSub: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict subtraction. Computes `self - v`, panicking on overflow
     /// regardless of whether overflow checks are enabled.
-    fn strict_sub(self, v: Self) -> <Self as Sub<Self>>::Output;
+    fn strict_sub(self, v: Self) -> Self::Output;
 }
 }
 
 c0nst::c0nst! {
 /// Performs multiplication that panics on overflow, even in release builds.
-pub c0nst trait StrictMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait StrictMul: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict multiplication. Computes `self * v`, panicking on overflow
     /// regardless of whether overflow checks are enabled.
-    fn strict_mul(self, v: Self) -> <Self as Mul<Self>>::Output;
+    fn strict_mul(self, v: Self) -> Self::Output;
 }
 }
 
@@ -50,6 +54,7 @@ macro_rules! strict_binary_impl {
     ($trait_name:ident, $method:ident, $overflowing:ident, $msg:expr, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             #[track_caller]
             fn $method(self, v: Self) -> Self {
@@ -102,19 +107,23 @@ strict_binary_impl_all!(
 
 c0nst::c0nst! {
 /// Performs division that panics on overflow, even in release builds.
-pub c0nst trait StrictDiv: Sized + [c0nst] Div<Self> {
+pub c0nst trait StrictDiv: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict division. Computes `self / v`, panicking on overflow (only
     /// possible for `MIN / -1` on a signed type) or if `v` is zero.
-    fn strict_div(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn strict_div(self, v: Self) -> Self::Output;
 }
 }
 
 c0nst::c0nst! {
 /// Performs a remainder operation that panics on overflow, even in release builds.
-pub c0nst trait StrictRem: Sized + [c0nst] Rem<Self> {
+pub c0nst trait StrictRem: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict remainder. Computes `self % v`, panicking on overflow (only
     /// possible for `MIN % -1` on a signed type) or if `v` is zero.
-    fn strict_rem(self, v: Self) -> <Self as Rem<Self>>::Output;
+    fn strict_rem(self, v: Self) -> Self::Output;
 }
 }
 
@@ -165,10 +174,12 @@ strict_neg_impl!(isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Computes the absolute value, panicking on overflow even in release builds.
-pub c0nst trait StrictAbs: Sized + [c0nst] Neg {
+pub c0nst trait StrictAbs: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict absolute value. Computes `self.abs()`, panicking for
     /// `MIN.strict_abs()` (the result can't be represented).
-    fn strict_abs(self) -> <Self as Neg>::Output;
+    fn strict_abs(self) -> Self::Output;
 }
 }
 
@@ -176,6 +187,7 @@ macro_rules! strict_abs_impl {
     ($($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl StrictAbs for $t {
+            type Output = $t;
             #[inline]
             #[track_caller]
             fn strict_abs(self) -> Self {
@@ -194,19 +206,23 @@ strict_abs_impl!(isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Performs a left shift that panics on overflowing shift amounts, even in release builds.
-pub c0nst trait StrictShl: Sized + [c0nst] Shl<u32> {
+pub c0nst trait StrictShl: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is
     /// larger than or equal to the number of bits in `self`.
-    fn strict_shl(self, rhs: u32) -> <Self as Shl<u32>>::Output;
+    fn strict_shl(self, rhs: u32) -> Self::Output;
 }
 }
 
 c0nst::c0nst! {
 /// Performs a right shift that panics on overflowing shift amounts, even in release builds.
-pub c0nst trait StrictShr: Sized + [c0nst] Shr<u32> {
+pub c0nst trait StrictShr: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict shift right. Computes `self >> rhs`, panicking if `rhs` is
     /// larger than or equal to the number of bits in `self`.
-    fn strict_shr(self, rhs: u32) -> <Self as Shr<u32>>::Output;
+    fn strict_shr(self, rhs: u32) -> Self::Output;
 }
 }
 
@@ -214,6 +230,7 @@ macro_rules! strict_shift_impl {
     ($trait_name:ident, $method:ident, $checked:ident, $msg:expr, $($t:ty)*) => {$(
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             #[track_caller]
             fn $method(self, rhs: u32) -> Self {
@@ -244,10 +261,12 @@ strict_shift_impl!(
 
 c0nst::c0nst! {
 /// Performs exponentiation that panics on overflow, even in release builds.
-pub c0nst trait StrictPow: Sized + [c0nst] Mul<Self> {
+pub c0nst trait StrictPow: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Strict exponentiation. Computes `self.pow(exp)`, panicking on
     /// overflow regardless of whether overflow checks are enabled.
-    fn strict_pow(self, exp: u32) -> <Self as Mul<Self>>::Output;
+    fn strict_pow(self, exp: u32) -> Self::Output;
 }
 }
 
@@ -265,12 +284,12 @@ pub c0nst trait StrictEuclid: [c0nst] Euclid {
     /// Strict Euclidean division. Computes `Euclid::div_euclid(self, v)`,
     /// panicking on overflow (only possible for `MIN / -1` on a signed type)
     /// or if `v` is zero.
-    fn strict_div_euclid(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn strict_div_euclid(self, v: Self) -> <Self as Euclid>::Output;
 
     /// Strict Euclidean remainder. Computes `Euclid::rem_euclid(self, v)`,
     /// panicking on overflow (only possible for `MIN % -1` on a signed type)
     /// or if `v` is zero.
-    fn strict_rem_euclid(self, v: Self) -> <Self as Rem<Self>>::Output;
+    fn strict_rem_euclid(self, v: Self) -> <Self as Euclid>::Output;
 }
 }
 

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -6,12 +6,12 @@
 //! exponent-dependent — Tier C for secret inputs.
 
 use core::num::Wrapping;
-use core::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub};
 
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, v: Self) -> Self {
                 <$t>::$method(self, v)
@@ -22,6 +22,7 @@ macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty, $rhs:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name<$rhs> for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, v: $rhs) -> Self {
                 <$t>::$method(self, v)
@@ -33,10 +34,12 @@ macro_rules! wrapping_impl {
 
 c0nst::c0nst! {
 /// Performs addition that wraps around on overflow.
-pub c0nst trait WrappingAdd: Sized + [c0nst] Add<Self> {
+pub c0nst trait WrappingAdd: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of
     /// the type.
-    fn wrapping_add(self, v: Self) -> <Self as Add<Self>>::Output;
+    fn wrapping_add(self, v: Self) -> Self::Output;
 }
 }
 
@@ -56,10 +59,12 @@ wrapping_impl!(WrappingAdd, wrapping_add, i128);
 
 c0nst::c0nst! {
 /// Performs subtraction that wraps around on overflow.
-pub c0nst trait WrappingSub: Sized + [c0nst] Sub<Self> {
+pub c0nst trait WrappingSub: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary
     /// of the type.
-    fn wrapping_sub(self, v: Self) -> <Self as Sub<Self>>::Output;
+    fn wrapping_sub(self, v: Self) -> Self::Output;
 }
 }
 
@@ -79,10 +84,12 @@ wrapping_impl!(WrappingSub, wrapping_sub, i128);
 
 c0nst::c0nst! {
 /// Performs multiplication that wraps around on overflow.
-pub c0nst trait WrappingMul: Sized + [c0nst] Mul<Self> {
+pub c0nst trait WrappingMul: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary
     /// of the type.
-    fn wrapping_mul(self, v: Self) -> <Self as Mul<Self>>::Output;
+    fn wrapping_mul(self, v: Self) -> Self::Output;
 }
 }
 
@@ -118,6 +125,7 @@ macro_rules! wrapping_unary_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self) -> $t {
                 <$t>::$method(self)
@@ -158,6 +166,7 @@ macro_rules! wrapping_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         c0nst::c0nst! {
         c0nst impl $trait_name for $t {
+            type Output = $t;
             #[inline]
             fn $method(self, rhs: u32) -> $t {
                 <$t>::$method(self, rhs)
@@ -169,7 +178,9 @@ macro_rules! wrapping_shift_impl {
 
 c0nst::c0nst! {
 /// Performs a left shift that does not panic.
-pub c0nst trait WrappingShl: Sized + [c0nst] Shl<usize> {
+pub c0nst trait WrappingShl: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
@@ -184,7 +195,7 @@ pub c0nst trait WrappingShl: Sized + [c0nst] Shl<usize> {
     /// assert_eq!(WrappingShl::wrapping_shl(x, 15), 0x8000);
     /// assert_eq!(WrappingShl::wrapping_shl(x, 16), 0x0001);
     /// ```
-    fn wrapping_shl(self, rhs: u32) -> <Self as Shl<usize>>::Output;
+    fn wrapping_shl(self, rhs: u32) -> Self::Output;
 }
 }
 
@@ -204,7 +215,9 @@ wrapping_shift_impl!(WrappingShl, wrapping_shl, i128);
 
 c0nst::c0nst! {
 /// Performs a right shift that does not panic.
-pub c0nst trait WrappingShr: Sized + [c0nst] Shr<usize> {
+pub c0nst trait WrappingShr: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
@@ -219,7 +232,7 @@ pub c0nst trait WrappingShr: Sized + [c0nst] Shr<usize> {
     /// assert_eq!(WrappingShr::wrapping_shr(x, 15), 0x0001);
     /// assert_eq!(WrappingShr::wrapping_shr(x, 16), 0x8000);
     /// ```
-    fn wrapping_shr(self, rhs: u32) -> <Self as Shr<usize>>::Output;
+    fn wrapping_shr(self, rhs: u32) -> Self::Output;
 }
 }
 
@@ -239,7 +252,9 @@ wrapping_shift_impl!(WrappingShr, wrapping_shr, i128);
 
 c0nst::c0nst! {
 /// Performs division that wraps around on overflow.
-pub c0nst trait WrappingDiv: Sized + [c0nst] Div<Self> {
+pub c0nst trait WrappingDiv: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) division. Computes `self / other`, wrapping around
     /// at the boundary of the type.
     ///
@@ -258,7 +273,7 @@ pub c0nst trait WrappingDiv: Sized + [c0nst] Div<Self> {
     /// assert_eq!(WrappingDiv::wrapping_div(100i8, 10), 10);
     /// assert_eq!(WrappingDiv::wrapping_div(i8::MIN, -1), i8::MIN); // wrapped!
     /// ```
-    fn wrapping_div(self, v: Self) -> <Self as Div<Self>>::Output;
+    fn wrapping_div(self, v: Self) -> Self::Output;
 }
 }
 
@@ -278,7 +293,9 @@ wrapping_impl!(WrappingDiv, wrapping_div, i128);
 
 c0nst::c0nst! {
 /// Performs a remainder operation that wraps around on overflow.
-pub c0nst trait WrappingRem: Sized + [c0nst] Rem<Self> {
+pub c0nst trait WrappingRem: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) remainder. Computes `self % other`, wrapping around
     /// at the boundary of the type.
     ///
@@ -296,7 +313,7 @@ pub c0nst trait WrappingRem: Sized + [c0nst] Rem<Self> {
     /// assert_eq!(WrappingRem::wrapping_rem(100i8, 10), 0);
     /// assert_eq!(WrappingRem::wrapping_rem(i8::MIN, -1), 0); // wrapped!
     /// ```
-    fn wrapping_rem(self, v: Self) -> <Self as Rem<Self>>::Output;
+    fn wrapping_rem(self, v: Self) -> Self::Output;
 }
 }
 
@@ -316,7 +333,9 @@ wrapping_impl!(WrappingRem, wrapping_rem, i128);
 
 c0nst::c0nst! {
 /// Computes the absolute value, wrapping around on overflow.
-pub c0nst trait WrappingAbs: Sized + [c0nst] Neg {
+pub c0nst trait WrappingAbs: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) absolute value. Computes `self.abs()`, wrapping
     /// around at the boundary of the type. The only wrapping case is
     /// `MIN.wrapping_abs() == MIN`.
@@ -327,7 +346,7 @@ pub c0nst trait WrappingAbs: Sized + [c0nst] Neg {
     /// assert_eq!(WrappingAbs::wrapping_abs(-100i8), 100);
     /// assert_eq!(WrappingAbs::wrapping_abs(i8::MIN), i8::MIN); // wrapped!
     /// ```
-    fn wrapping_abs(self) -> <Self as Neg>::Output;
+    fn wrapping_abs(self) -> Self::Output;
 }
 }
 
@@ -340,7 +359,9 @@ wrapping_unary_impl!(WrappingAbs, wrapping_abs, i128);
 
 c0nst::c0nst! {
 /// Performs exponentiation that wraps around on overflow.
-pub c0nst trait WrappingPow: Sized + [c0nst] Mul<Self> {
+pub c0nst trait WrappingPow: Sized {
+    /// The result type (`Self` for the primitive impls).
+    type Output;
     /// Wrapping (modular) exponentiation. Computes `self.pow(exp)`, wrapping
     /// around at the boundary of the type.
     ///
@@ -350,7 +371,7 @@ pub c0nst trait WrappingPow: Sized + [c0nst] Mul<Self> {
     /// assert_eq!(WrappingPow::wrapping_pow(3u8, 5), 243);
     /// assert_eq!(WrappingPow::wrapping_pow(3u8, 6), 217); // wrapped!
     /// ```
-    fn wrapping_pow(self, exp: u32) -> <Self as Mul<Self>>::Output;
+    fn wrapping_pow(self, exp: u32) -> Self::Output;
 }
 }
 
@@ -382,51 +403,38 @@ fn test_wrapping_div_rem_abs_pow() {
 
 // Wrapping<T> blanket impls stay non-const: std's `Add`/`Sub`/`Mul`/`Neg`/`Shl`/`Shr`
 // impls for `Wrapping<T>` are not const-trait impls (same situation as Num).
-impl<T: WrappingAdd<Output = T>> WrappingAdd for Wrapping<T>
-where
-    Wrapping<T>: Add<Output = Wrapping<T>>,
-{
+impl<T: WrappingAdd<Output = T>> WrappingAdd for Wrapping<T> {
+    type Output = Wrapping<T>;
     fn wrapping_add(self, v: Self) -> Self {
         Wrapping(self.0.wrapping_add(v.0))
     }
 }
-impl<T: WrappingSub<Output = T>> WrappingSub for Wrapping<T>
-where
-    Wrapping<T>: Sub<Output = Wrapping<T>>,
-{
+impl<T: WrappingSub<Output = T>> WrappingSub for Wrapping<T> {
+    type Output = Wrapping<T>;
     fn wrapping_sub(self, v: Self) -> Self {
         Wrapping(self.0.wrapping_sub(v.0))
     }
 }
-impl<T: WrappingMul<Output = T>> WrappingMul for Wrapping<T>
-where
-    Wrapping<T>: Mul<Output = Wrapping<T>>,
-{
+impl<T: WrappingMul<Output = T>> WrappingMul for Wrapping<T> {
+    type Output = Wrapping<T>;
     fn wrapping_mul(self, v: Self) -> Self {
         Wrapping(self.0.wrapping_mul(v.0))
     }
 }
-impl<T: WrappingNeg<Output = T>> WrappingNeg for Wrapping<T>
-where
-    Wrapping<T>: Neg<Output = Wrapping<T>>,
-{
+impl<T: WrappingNeg<Output = T>> WrappingNeg for Wrapping<T> {
     type Output = Wrapping<T>;
     fn wrapping_neg(self) -> Self {
         Wrapping(self.0.wrapping_neg())
     }
 }
-impl<T: WrappingShl<Output = T>> WrappingShl for Wrapping<T>
-where
-    Wrapping<T>: Shl<usize, Output = Wrapping<T>>,
-{
+impl<T: WrappingShl<Output = T>> WrappingShl for Wrapping<T> {
+    type Output = Wrapping<T>;
     fn wrapping_shl(self, rhs: u32) -> Self {
         Wrapping(self.0.wrapping_shl(rhs))
     }
 }
-impl<T: WrappingShr<Output = T>> WrappingShr for Wrapping<T>
-where
-    Wrapping<T>: Shr<usize, Output = Wrapping<T>>,
-{
+impl<T: WrappingShr<Output = T>> WrappingShr for Wrapping<T> {
+    type Output = Wrapping<T>;
     fn wrapping_shr(self, rhs: u32) -> Self {
         Wrapping(self.0.wrapping_shr(rhs))
     }

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -217,7 +217,7 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
 /// assert_eq!(checked_pow(0u32, 0), Some(1)); // Be aware if this case affect you
 /// ```
 #[inline]
-pub fn checked_pow<T: Clone + One + CheckedMul + core::ops::Mul<Output = T>>(
+pub fn checked_pow<T: Clone + One + CheckedMul<Output = T>>(
     mut base: T,
     mut exp: usize,
 ) -> Option<T> {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,7 +1,7 @@
 use core::num::Wrapping;
 use core::ops::Neg;
 
-use crate::Num;
+use crate::Zero;
 use crate::float::FloatCore;
 
 c0nst::c0nst! {
@@ -33,7 +33,7 @@ pub c0nst trait Signum: Sized {
 
 c0nst::c0nst! {
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
-pub c0nst trait Signed: Sized + [c0nst] Num + [c0nst] Neg + [c0nst] Signum {
+pub c0nst trait Signed: Sized + [c0nst] Zero + [c0nst] PartialOrd + [c0nst] Neg + [c0nst] Signum {
     /// Computes the absolute value.
     ///
     /// For `f32` and `f64`, `NaN` will be returned if the number is `NaN`.
@@ -121,7 +121,7 @@ impl<T: Signum<Output = T>> Signum for Wrapping<T> {
 
 impl<T: Signed + Neg<Output = T> + Signum<Output = T>> Signed for Wrapping<T>
 where
-    Wrapping<T>: Num + Neg<Output = Wrapping<T>>,
+    Wrapping<T>: Zero + PartialOrd + Neg<Output = Wrapping<T>>,
 {
     #[inline]
     fn abs(self) -> Self {
@@ -238,7 +238,7 @@ pub c0nst fn signum<T: [c0nst] Signed + [c0nst] Signum<Output = T> + [c0nst] Des
 
 c0nst::c0nst! {
 /// A trait for values which cannot be negative
-pub c0nst trait Unsigned: [c0nst] Num {}
+pub c0nst trait Unsigned: Sized {}
 }
 
 macro_rules! empty_trait_impl {
@@ -252,7 +252,7 @@ macro_rules! empty_trait_impl {
 empty_trait_impl!(Unsigned for usize u8 u16 u32 u64 u128);
 
 // Same `Wrapping<T>: Num` story as `Signed`: non-const blanket impl.
-impl<T: Unsigned> Unsigned for Wrapping<T> where Wrapping<T>: Num {}
+impl<T: Unsigned> Unsigned for Wrapping<T> {}
 
 #[test]
 fn unsigned_wrapping_is_unsigned() {


### PR DESCRIPTION
Breaking (0.2.0). Removes the `core::ops` operator supertrait that the arithmetic traits carried solely to source their return type, replacing the projection with a fresh trait-local `type Output`.

## Why

`WrappingAdd: Add<Self>` returning `<Self as Add<Self>>::Output` leaked an `Add<Output = Self>` requirement onto every consumer, and forced a backend to implement the operator just to implement the wrapping trait — even though `wrapping_add` is a distinct operation from `+` (a backend whose `+` panics still has a well-defined `wrapping_add`). Each such trait now carries its own `type Output` and drops the operator supertrait.

- Consumers bound `WrappingAdd<Output = Self>` (the trait they use), not `WrappingAdd + Add<Output = Self>` (the operator they don't).
- **Non-`Copy` backends keep the `impl Trait for &T` owned-return path** — that is the reason for an associated `Output` rather than a bare `-> Self`. This was the hard requirement driving the design.
- Primitive impls are unchanged (their `Output` is `Self`); `PrimInt`'s `CheckedAdd<Output = Self>` bounds and the `Wrapping<T>` blanket impls keep resolving.

## Scope (from a 4-way audit of the whole trait surface)

- **51 traits** across checked/wrapping/saturating/overflowing/strict/rounding(`DivCeil`/`DivFloor`)/carrying(`CarryingAdd`/`BorrowingSub`)/bits(`UnboundedShl/Shr`, `ShlExact/ShrExact`) → fresh `type Output`.
- **`Euclid`** → single `type Output` (div and rem share it); `Checked`/`Wrapping`/`Overflowing`/`StrictEuclid` re-spell through `<Self as Euclid>::Output`.
- **`CarryingMul`** → second assoc type for the high word (alongside `type Unsigned`).
- **Pure-leak supertrait drops:** `WideningMul`'s dead `Mul` (returns via `type Wide`); the `Rem` on `MultipleOf`/`DivExact`/`NextMultipleOf` that never sourced a return.
- **Sign traits relaxed:** `Signed`: `Num` → `Zero + PartialOrd + Neg + Signum`; `Unsigned`: bare marker — so sign queries don't drag in `Div`/`Rem`/`One` (a CT/non-divisible signed type can now answer `is_positive`/`abs`).

## Migration

Replace `T: WrappingAdd + Add<Output = T>`-style bounds with `T: WrappingAdd<Output = T>`, and drop operator bounds that were only present to pin the projection. Impl sites are unchanged.

Verified: stable (lib + integration + 259 doctests), nightly `--features nightly,ct` (const surface + 261 doctests), clippy clean on default + `ct`, and the no_std / `ct` / `libm` build configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded numeric operation support with more consistent result typing across checked, overflowing, saturating, wrapping, and Euclidean operations.
  * Improved compatibility for custom numeric types by reducing reliance on standard operator traits.

* **Bug Fixes**
  * Simplified signed/unsigned handling and power calculations to work with narrower capability requirements.
  * Updated public arithmetic APIs to return clearer, more predictable output types.

* **Chores**
  * Bumped the package version to **0.2.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->