### PR TITLE
Add BitsPrecision: runtime cross-carrier width (0.2.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kaidokert/num-traits"
 name = "const-num-traits"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 # Include-list of the files that ship. Anything not listed here is never packaged.
 include = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub use crate::int::{PrimBits, PrimInt};
 pub use crate::ops::bits::{
     BitWidth, BitsPrecision, DepositBits, ExtractBits, FunnelShl, FunnelShr, HighestOne,
     IsolateHighestOne, IsolateLowestOne, LowestOne, ShlExact, ShrExact, UnboundedShl, UnboundedShr,
+    WithPrecision,
 };
 pub use crate::ops::byte_slice::{ByteSliceError, ByteSliceErrorKind, FromByteSlice};
 pub use crate::ops::bytes::{FromBytes, ToBytes};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ pub use crate::cast::{AsPrimitive, FromPrimitive, NumCast, ToPrimitive, cast};
 pub use crate::identities::{ConstOne, ConstZero, One, Zero, one, zero};
 pub use crate::int::{PrimBits, PrimInt};
 pub use crate::ops::bits::{
-    BitWidth, DepositBits, ExtractBits, FunnelShl, FunnelShr, HighestOne, IsolateHighestOne,
-    IsolateLowestOne, LowestOne, ShlExact, ShrExact, UnboundedShl, UnboundedShr,
+    BitWidth, BitsPrecision, DepositBits, ExtractBits, FunnelShl, FunnelShr, HighestOne,
+    IsolateHighestOne, IsolateLowestOne, LowestOne, ShlExact, ShrExact, UnboundedShl, UnboundedShr,
 };
 pub use crate::ops::byte_slice::{ByteSliceError, ByteSliceErrorKind, FromByteSlice};
 pub use crate::ops::bytes::{FromBytes, ToBytes};

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -454,20 +454,26 @@ c0nst::c0nst! {
 ///
 /// A method, not an associated `const`: a variable-width carrier's width is only
 /// known at runtime — and there the identity is *minimal*-width, so
-/// `bits_precision(Zero::zero())` is `0`, **not** the operating width. Probe a
+/// `bits_precision(&Zero::zero())` is `0`, **not** the operating width. Probe a
 /// full-width witness (typically the modulus), never the identity. See
 /// [`WithPrecision`] to establish a width constructively.
+///
+/// Takes `&self`: reading a value's width never consumes it, so — like
+/// [`FromBytes`](crate::FromBytes) — the by-value operand convention does not
+/// apply. Borrowing is what lets a non-`Copy` carrier be *queried as a witness*
+/// without a clone, which is exactly how [`WithPrecision`]'s `_of` forms stay
+/// `Copy`-free.
 pub c0nst trait BitsPrecision: Sized {
     /// The number of bits `self` operates over (its constructed width).
     ///
     /// ```
     /// use const_num_traits::BitsPrecision;
     ///
-    /// assert_eq!(BitsPrecision::bits_precision(0u32), 32);
-    /// assert_eq!(BitsPrecision::bits_precision(u32::MAX), 32);
-    /// assert_eq!(BitsPrecision::bits_precision(7u8), 8);
+    /// assert_eq!(BitsPrecision::bits_precision(&0u32), 32);
+    /// assert_eq!(BitsPrecision::bits_precision(&u32::MAX), 32);
+    /// assert_eq!(BitsPrecision::bits_precision(&7u8), 8);
     /// ```
-    fn bits_precision(self) -> u32;
+    fn bits_precision(&self) -> u32;
 }
 }
 
@@ -476,7 +482,7 @@ macro_rules! bits_precision_impl {
         c0nst::c0nst! {
         c0nst impl BitsPrecision for $t {
             #[inline]
-            fn bits_precision(self) -> u32 {
+            fn bits_precision(&self) -> u32 {
                 <$t>::BITS
             }
         }
@@ -507,6 +513,11 @@ c0nst::c0nst! {
 /// value only to a *representation-compatible* width — for a fixed-point carrier,
 /// the same fractional format — which is why the ergonomic forms take a witness
 /// *value* rather than a bare bit count.
+///
+/// The witness `_of` forms borrow the witness (`&Self`) and read its width
+/// through [`BitsPrecision::bits_precision`], which also borrows — so they carry
+/// **no `Copy` bound** and serve a `Clone`-generic (non-`Copy`) carrier, the case
+/// the whole family exists for.
 ///
 /// ```
 /// use const_num_traits::WithPrecision;
@@ -545,10 +556,7 @@ pub c0nst trait WithPrecision: [c0nst] BitsPrecision {
     /// `witness` value — typically the modulus a reducer operates over. Prefer
     /// this to hand-picking a bit count: the witness carries the intended width.
     #[inline]
-    fn widen_to_precision_of(self, witness: &Self) -> Self
-    where
-        Self: Copy,
-    {
+    fn widen_to_precision_of(self, witness: &Self) -> Self {
         self.widen_to_precision(witness.bits_precision())
     }
 
@@ -557,7 +565,7 @@ pub c0nst trait WithPrecision: [c0nst] BitsPrecision {
     #[inline]
     fn zero_with_precision_of(witness: &Self) -> Self
     where
-        Self: [c0nst] crate::Zero + Copy,
+        Self: [c0nst] crate::Zero,
     {
         Self::zero_with_precision(witness.bits_precision())
     }
@@ -566,7 +574,7 @@ pub c0nst trait WithPrecision: [c0nst] BitsPrecision {
     #[inline]
     fn one_with_precision_of(witness: &Self) -> Self
     where
-        Self: [c0nst] crate::One + Copy,
+        Self: [c0nst] crate::One,
     {
         Self::one_with_precision(witness.bits_precision())
     }
@@ -760,6 +768,66 @@ mod tests {
         let z: u16 = WithPrecision::zero_with_precision(64);
         let o: u16 = WithPrecision::one_with_precision(64);
         assert_eq!((z, o), (0, 1));
+    }
+
+    // A runtime-width, **non-`Copy`** carrier (only `Clone`) — the ed25519
+    // `sha512_modq` case. Proves the witness `_of` forms carry no `Copy` bound and
+    // establish width from a borrowed witness without cloning the value.
+    #[derive(Clone, PartialEq, Debug)]
+    struct RtWidth {
+        val: u64,
+        width: u32,
+    }
+
+    impl crate::Zero for RtWidth {
+        fn zero() -> Self {
+            RtWidth { val: 0, width: 0 }
+        }
+        fn set_zero(&mut self) {
+            *self = <Self as crate::Zero>::zero();
+        }
+        fn is_zero(&self) -> bool {
+            self.val == 0
+        }
+    }
+    impl crate::One for RtWidth {
+        fn one() -> Self {
+            RtWidth { val: 1, width: 1 }
+        }
+        fn set_one(&mut self) {
+            *self = <Self as crate::One>::one();
+        }
+        fn is_one(&self) -> bool {
+            self.val == 1
+        }
+    }
+    impl BitsPrecision for RtWidth {
+        fn bits_precision(&self) -> u32 {
+            self.width
+        }
+    }
+    impl WithPrecision for RtWidth {
+        fn widen_to_precision(self, bits_precision: u32) -> Self {
+            RtWidth {
+                val: self.val,
+                width: self.width.max(bits_precision),
+            }
+        }
+    }
+
+    #[test]
+    fn with_precision_serves_non_copy_carrier() {
+        let modulus = RtWidth { val: 7, width: 256 };
+        // zero/one seeded at the witness width — the idiom `sha512_modq` needed.
+        // `modulus` is only borrowed: it is still usable afterward.
+        let z = RtWidth::zero_with_precision_of(&modulus);
+        let o = RtWidth::one_with_precision_of(&modulus);
+        assert_eq!(z, RtWidth { val: 0, width: 256 });
+        assert_eq!(o, RtWidth { val: 1, width: 256 });
+        // widen an owned value to the witness width; witness survives.
+        let widened = RtWidth { val: 3, width: 8 }.widen_to_precision_of(&modulus);
+        assert_eq!(widened, RtWidth { val: 3, width: 256 });
+        assert_eq!(modulus.width, 256); // witness not consumed
     }
 
     #[test]

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -441,9 +441,9 @@ c0nst::c0nst! {
 /// the type's bit-width for fixed carriers (`u32` → 32, value-independent), the
 /// constructed length for variable-width bignums (per value).
 ///
-/// A runtime method, not a `const`: a variable-width carrier has no compile-time
-/// width. Contrast [`BitWidth::bit_width`] (*bit-length* — significant bits,
-/// always `<= bits_precision()`).
+/// A method, not an associated `const`: a variable-width carrier's width is only
+/// known at runtime. Contrast [`BitWidth::bit_width`] (*bit-length* —
+/// significant bits, always `<= bits_precision()`).
 pub c0nst trait BitsPrecision: Sized {
     /// The number of bits `self` operates over (its constructed width).
     ///

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -437,6 +437,48 @@ macro_rules! bit_width_impl {
 bit_width_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
+/// Reports a value's operating **width** — the number of bits it was
+/// constructed over.
+///
+/// For built-in integers and other fixed-width carriers this is the type's
+/// bit-width and is value-independent; for variable-width carriers (runtime-len
+/// bignums) it is the constructed length, so it is reported per value.
+///
+/// Deliberately a runtime method, never an associated `const`: a variable-width
+/// carrier has no compile-time width, and a `const` width would invite the
+/// fixed-width proxies (`size_of::<T>() * 8`, `count_zeros(zero())`) this trait
+/// replaces. Contrast [`BitWidth::bit_width`], which reports *bit-length* — the
+/// significant bits of the value, always `<= bits_precision()`.
+pub c0nst trait BitsPrecision: Sized {
+    /// The number of bits `self` operates over (its constructed width).
+    ///
+    /// ```
+    /// use const_num_traits::BitsPrecision;
+    ///
+    /// assert_eq!(BitsPrecision::bits_precision(0u32), 32);
+    /// assert_eq!(BitsPrecision::bits_precision(u32::MAX), 32);
+    /// assert_eq!(BitsPrecision::bits_precision(7u8), 8);
+    /// ```
+    fn bits_precision(self) -> u32;
+}
+}
+
+macro_rules! bits_precision_impl {
+    ($($t:ty)*) => {$(
+        c0nst::c0nst! {
+        c0nst impl BitsPrecision for $t {
+            #[inline]
+            fn bits_precision(self) -> u32 {
+                <$t>::BITS
+            }
+        }
+        }
+    )*};
+}
+
+bits_precision_impl!(usize u8 u16 u32 u64 u128);
+
+c0nst::c0nst! {
 /// Scatters bits through a mask (the PDEP operation).
 pub c0nst trait DepositBits: Sized {
     /// Scatters the contiguous low-order bits of `self` into the positions

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -438,31 +438,21 @@ bit_width_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
 /// A value's operating **width** in bits — how many bits it is represented over,
-/// which may be **less than its storage capacity**. Named after
-/// `crypto-bigint`'s `BoxedUint::bits_precision`.
+/// possibly **less than its storage capacity**. Fixed per type for a fixed-width
+/// carrier (`u32` → 32, `arbitrary-int`'s `u48` → 48), per-value for a
+/// variable-width bignum. Named after `crypto-bigint`'s `BoxedUint::bits_precision`.
+/// Contrast [`BitWidth::bit_width`] (*bit-length* — significant bits,
+/// `<= bits_precision()`).
 ///
-/// For a fixed-width carrier the width is a property of the type and
-/// value-independent (`u32` → 32; `arbitrary-int`'s `u48` → 48, below its `u64`
-/// store; a fixed-point `Q48.8` → 56); for a variable-width carrier (a
-/// runtime-length bignum) it is the value's constructed length. Contrast
-/// [`BitWidth::bit_width`] (*bit-length* — the significant bits of the value,
-/// always `<= bits_precision()`).
+/// Binary carriers only — not decimals/floats/rationals (non-binary precision).
 ///
-/// A binary quantity only: types whose "precision" is not a binary width below a
-/// binary capacity — decimals (base-10 digits), floats (fixed mantissa),
-/// rationals — do not implement it.
+/// **Footgun:** on a variable-width carrier the identity is minimal-width, so
+/// `bits_precision(&Zero::zero())` is `0`, not the operating width — probe a
+/// full-width witness (the modulus), never the identity. See [`WithPrecision`].
 ///
-/// A method, not an associated `const`: a variable-width carrier's width is only
-/// known at runtime — and there the identity is *minimal*-width, so
-/// `bits_precision(&Zero::zero())` is `0`, **not** the operating width. Probe a
-/// full-width witness (typically the modulus), never the identity. See
-/// [`WithPrecision`] to establish a width constructively.
-///
-/// Takes `&self`: reading a value's width never consumes it, so — like
-/// [`FromBytes`](crate::FromBytes) — the by-value operand convention does not
-/// apply. Borrowing is what lets a non-`Copy` carrier be *queried as a witness*
-/// without a clone, which is exactly how [`WithPrecision`]'s `_of` forms stay
-/// `Copy`-free.
+/// `&self`, not `self`: a width query never consumes its value (cf.
+/// [`FromBytes`](crate::FromBytes)), and borrowing lets a non-`Copy` carrier be a
+/// witness without a clone — how [`WithPrecision`]'s `_of` forms stay `Copy`-free.
 pub c0nst trait BitsPrecision: Sized {
     /// The number of bits `self` operates over (its constructed width).
     ///
@@ -494,30 +484,21 @@ bits_precision_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
 /// Establishes a value's operating **width** from a witness — the constructive
-/// companion to [`BitsPrecision`], which *reads* it. The method names mirror the
-/// width-carrying constructors on `crypto-bigint`'s `BoxedUint`
-/// (`zero_with_precision`, `one_with_precision`, `widen`), lifted to a
-/// cross-carrier trait.
+/// companion to [`BitsPrecision`]. Method names mirror `crypto-bigint`'s
+/// `BoxedUint::{zero_with_precision, one_with_precision, widen}`.
 ///
-/// [`Zero::zero`](crate::Zero::zero) and [`One::one`](crate::One::one) are
-/// *minimal*-width on a runtime-width carrier: `zero()` is a 0-bit value, `one()`
-/// a 1-bit value. Generic code that seeds an accumulator with `zero()` and drives
-/// it toward a modulus width then operates at the seed width and wraps early —
+/// **Why it exists:** [`Zero::zero`](crate::Zero::zero)/[`One::one`](crate::One::one)
+/// are minimal-width on a runtime-width carrier, so a reducer seeded with `zero()`
+/// and grown toward a modulus width operates at the seed width and wraps early —
 /// correct on a fixed-width type, silently truncated on a variable-width one.
-/// Seeding at the modulus width removes the trap: `T::zero_with_precision_of(&m)`.
+/// `T::zero_with_precision_of(&m)` seeds at the modulus width instead.
 ///
-/// [`widen_to_precision`](Self::widen_to_precision) **never shrinks** and
-/// preserves the numeric value. On a fixed-width carrier (a primitive,
-/// `arbitrary-int`'s `u48`, a fixed-point type) the width is the type, so it is
-/// the identity and the requested precision is ignored. Widening preserves the
-/// value only to a *representation-compatible* width — for a fixed-point carrier,
-/// the same fractional format — which is why the ergonomic forms take a witness
-/// *value* rather than a bare bit count.
-///
-/// The witness `_of` forms borrow the witness (`&Self`) and read its width
-/// through [`BitsPrecision::bits_precision`], which also borrows — so they carry
-/// **no `Copy` bound** and serve a `Clone`-generic (non-`Copy`) carrier, the case
-/// the whole family exists for.
+/// [`widen_to_precision`](Self::widen_to_precision) grows, never shrinks, and
+/// preserves the value (identity on a fixed-width carrier). It preserves value
+/// only to a *representation-compatible* width — a fixed-point carrier's fractional
+/// format must match — which is why the `_of` forms take a witness *value*, not a
+/// bit count. Those forms borrow the witness, so they carry **no `Copy` bound** and
+/// serve `Clone`-only carriers, the case the family exists for.
 ///
 /// ```
 /// use const_num_traits::WithPrecision;
@@ -770,9 +751,8 @@ mod tests {
         assert_eq!((z, o), (0, 1));
     }
 
-    // A runtime-width, **non-`Copy`** carrier (only `Clone`) — the ed25519
-    // `sha512_modq` case. Proves the witness `_of` forms carry no `Copy` bound and
-    // establish width from a borrowed witness without cloning the value.
+    // A runtime-width, non-`Copy` carrier (only `Clone`). Proves the witness `_of`
+    // forms carry no `Copy` bound and establish width from a borrowed witness.
     #[derive(Clone, PartialEq, Debug)]
     struct RtWidth {
         val: u64,
@@ -818,8 +798,7 @@ mod tests {
     #[test]
     fn with_precision_serves_non_copy_carrier() {
         let modulus = RtWidth { val: 7, width: 256 };
-        // zero/one seeded at the witness width — the idiom `sha512_modq` needed.
-        // `modulus` is only borrowed: it is still usable afterward.
+        // zero/one seeded at the witness width; `modulus` is only borrowed.
         let z = RtWidth::zero_with_precision_of(&modulus);
         let o = RtWidth::one_with_precision_of(&modulus);
         assert_eq!(z, RtWidth { val: 0, width: 256 });

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -437,13 +437,26 @@ macro_rules! bit_width_impl {
 bit_width_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
-/// A value's operating **width** — the number of bits it was constructed over:
-/// the type's bit-width for fixed carriers (`u32` → 32, value-independent), the
-/// constructed length for variable-width bignums (per value).
+/// A value's operating **width** in bits — how many bits it is represented over,
+/// which may be **less than its storage capacity**. Named after
+/// `crypto-bigint`'s `BoxedUint::bits_precision`.
+///
+/// For a fixed-width carrier the width is a property of the type and
+/// value-independent (`u32` → 32; `arbitrary-int`'s `u48` → 48, below its `u64`
+/// store; a fixed-point `Q48.8` → 56); for a variable-width carrier (a
+/// runtime-length bignum) it is the value's constructed length. Contrast
+/// [`BitWidth::bit_width`] (*bit-length* — the significant bits of the value,
+/// always `<= bits_precision()`).
+///
+/// A binary quantity only: types whose "precision" is not a binary width below a
+/// binary capacity — decimals (base-10 digits), floats (fixed mantissa),
+/// rationals — do not implement it.
 ///
 /// A method, not an associated `const`: a variable-width carrier's width is only
-/// known at runtime. Contrast [`BitWidth::bit_width`] (*bit-length* —
-/// significant bits, always `<= bits_precision()`).
+/// known at runtime — and there the identity is *minimal*-width, so
+/// `bits_precision(Zero::zero())` is `0`, **not** the operating width. Probe a
+/// full-width witness (typically the modulus), never the identity. See
+/// [`WithPrecision`] to establish a width constructively.
 pub c0nst trait BitsPrecision: Sized {
     /// The number of bits `self` operates over (its constructed width).
     ///
@@ -472,6 +485,108 @@ macro_rules! bits_precision_impl {
 }
 
 bits_precision_impl!(usize u8 u16 u32 u64 u128);
+
+c0nst::c0nst! {
+/// Establishes a value's operating **width** from a witness — the constructive
+/// companion to [`BitsPrecision`], which *reads* it. The method names mirror the
+/// width-carrying constructors on `crypto-bigint`'s `BoxedUint`
+/// (`zero_with_precision`, `one_with_precision`, `widen`), lifted to a
+/// cross-carrier trait.
+///
+/// [`Zero::zero`](crate::Zero::zero) and [`One::one`](crate::One::one) are
+/// *minimal*-width on a runtime-width carrier: `zero()` is a 0-bit value, `one()`
+/// a 1-bit value. Generic code that seeds an accumulator with `zero()` and drives
+/// it toward a modulus width then operates at the seed width and wraps early —
+/// correct on a fixed-width type, silently truncated on a variable-width one.
+/// Seeding at the modulus width removes the trap: `T::zero_with_precision_of(&m)`.
+///
+/// [`widen_to_precision`](Self::widen_to_precision) **never shrinks** and
+/// preserves the numeric value. On a fixed-width carrier (a primitive,
+/// `arbitrary-int`'s `u48`, a fixed-point type) the width is the type, so it is
+/// the identity and the requested precision is ignored. Widening preserves the
+/// value only to a *representation-compatible* width — for a fixed-point carrier,
+/// the same fractional format — which is why the ergonomic forms take a witness
+/// *value* rather than a bare bit count.
+///
+/// ```
+/// use const_num_traits::WithPrecision;
+///
+/// // Fixed-width: width is the type; the requested precision is ignored.
+/// assert_eq!(WithPrecision::widen_to_precision(5u32, 256), 5u32);
+/// assert_eq!(WithPrecision::zero_with_precision_of(&99u32), 0u32);
+/// let one: u32 = WithPrecision::one_with_precision(128);
+/// assert_eq!(one, 1);
+/// ```
+pub c0nst trait WithPrecision: [c0nst] BitsPrecision {
+    /// Returns `self` re-represented over a width of **at least**
+    /// `bits_precision`, preserving its numeric value. Never shrinks; on a
+    /// fixed-width carrier the width is the type and this is the identity.
+    fn widen_to_precision(self, bits_precision: u32) -> Self;
+
+    /// A [`Zero`](crate::Zero) carried at a width of at least `bits_precision`.
+    #[inline]
+    fn zero_with_precision(bits_precision: u32) -> Self
+    where
+        Self: [c0nst] crate::Zero,
+    {
+        Self::zero().widen_to_precision(bits_precision)
+    }
+
+    /// A [`One`](crate::One) carried at a width of at least `bits_precision`.
+    #[inline]
+    fn one_with_precision(bits_precision: u32) -> Self
+    where
+        Self: [c0nst] crate::One,
+    {
+        Self::one().widen_to_precision(bits_precision)
+    }
+
+    /// [`widen_to_precision`](Self::widen_to_precision) to the width of a
+    /// `witness` value — typically the modulus a reducer operates over. Prefer
+    /// this to hand-picking a bit count: the witness carries the intended width.
+    #[inline]
+    fn widen_to_precision_of(self, witness: &Self) -> Self
+    where
+        Self: Copy,
+    {
+        self.widen_to_precision(witness.bits_precision())
+    }
+
+    /// A [`Zero`](crate::Zero) carried at the `witness`'s width — the width-safe
+    /// seed for a generic accumulator.
+    #[inline]
+    fn zero_with_precision_of(witness: &Self) -> Self
+    where
+        Self: [c0nst] crate::Zero + Copy,
+    {
+        Self::zero_with_precision(witness.bits_precision())
+    }
+
+    /// A [`One`](crate::One) carried at the `witness`'s width.
+    #[inline]
+    fn one_with_precision_of(witness: &Self) -> Self
+    where
+        Self: [c0nst] crate::One + Copy,
+    {
+        Self::one_with_precision(witness.bits_precision())
+    }
+}
+}
+
+macro_rules! with_precision_impl {
+    ($($t:ty)*) => {$(
+        c0nst::c0nst! {
+        c0nst impl WithPrecision for $t {
+            #[inline]
+            fn widen_to_precision(self, _bits_precision: u32) -> $t {
+                self
+            }
+        }
+        }
+    )*};
+}
+
+with_precision_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
 /// Scatters bits through a mask (the PDEP operation).
@@ -633,6 +748,18 @@ mod tests {
         assert_eq!(BitWidth::bit_width(1u8), 1);
         assert_eq!(BitWidth::bit_width(255u8), 8);
         assert_eq!(BitWidth::bit_width(0x0101u16), 9);
+    }
+
+    #[test]
+    fn with_precision_is_identity_on_fixed_width() {
+        // Fixed-width carriers: width is the type, requested precision ignored.
+        assert_eq!(WithPrecision::widen_to_precision(5u32, 256), 5);
+        assert_eq!(WithPrecision::widen_to_precision_of(5u32, &9999u32), 5);
+        assert_eq!(WithPrecision::zero_with_precision_of(&99u32), 0u32);
+        assert_eq!(WithPrecision::one_with_precision_of(&99u8), 1u8);
+        let z: u16 = WithPrecision::zero_with_precision(64);
+        let o: u16 = WithPrecision::one_with_precision(64);
+        assert_eq!((z, o), (0, 1));
     }
 
     #[test]

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -480,7 +480,7 @@ macro_rules! bits_precision_impl {
     )*};
 }
 
-bits_precision_impl!(usize u8 u16 u32 u64 u128);
+bits_precision_impl!(usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Establishes a value's operating **width** from a witness — the constructive
@@ -575,7 +575,7 @@ macro_rules! with_precision_impl {
     )*};
 }
 
-with_precision_impl!(usize u8 u16 u32 u64 u128);
+with_precision_impl!(usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128);
 
 c0nst::c0nst! {
 /// Scatters bits through a mask (the PDEP operation).
@@ -749,6 +749,10 @@ mod tests {
         let z: u16 = WithPrecision::zero_with_precision(64);
         let o: u16 = WithPrecision::one_with_precision(64);
         assert_eq!((z, o), (0, 1));
+        // signed carriers: width is the type (`i32::BITS`), ops are the identity.
+        assert_eq!(BitsPrecision::bits_precision(&-1i32), 32);
+        assert_eq!(WithPrecision::widen_to_precision(-5i16, 128), -5);
+        assert_eq!(WithPrecision::zero_with_precision_of(&-9i64), 0i64);
     }
 
     // A runtime-width, non-`Copy` carrier (only `Clone`). Proves the witness `_of`

--- a/src/ops/bits.rs
+++ b/src/ops/bits.rs
@@ -437,18 +437,13 @@ macro_rules! bit_width_impl {
 bit_width_impl!(usize u8 u16 u32 u64 u128);
 
 c0nst::c0nst! {
-/// Reports a value's operating **width** — the number of bits it was
-/// constructed over.
+/// A value's operating **width** — the number of bits it was constructed over:
+/// the type's bit-width for fixed carriers (`u32` → 32, value-independent), the
+/// constructed length for variable-width bignums (per value).
 ///
-/// For built-in integers and other fixed-width carriers this is the type's
-/// bit-width and is value-independent; for variable-width carriers (runtime-len
-/// bignums) it is the constructed length, so it is reported per value.
-///
-/// Deliberately a runtime method, never an associated `const`: a variable-width
-/// carrier has no compile-time width, and a `const` width would invite the
-/// fixed-width proxies (`size_of::<T>() * 8`, `count_zeros(zero())`) this trait
-/// replaces. Contrast [`BitWidth::bit_width`], which reports *bit-length* — the
-/// significant bits of the value, always `<= bits_precision()`.
+/// A runtime method, not a `const`: a variable-width carrier has no compile-time
+/// width. Contrast [`BitWidth::bit_width`] (*bit-length* — significant bits,
+/// always `<= bits_precision()`).
 pub c0nst trait BitsPrecision: Sized {
     /// The number of bits `self` operates over (its constructed width).
     ///

--- a/tests/const_nightly.rs
+++ b/tests/const_nightly.rs
@@ -9,12 +9,12 @@
 use const_num_traits::Signed;
 use const_num_traits::ops::overflowing::{OverflowingAdd, OverflowingShl};
 use const_num_traits::{
-    AbsDiff, BorrowingSub, CarryingAdd, CarryingMul, CarrylessMul, CastSigned, CastUnsigned,
-    CheckedAddSigned, CheckedCast, CheckedPow, CheckedSignedDiff, ClampMagnitude, DepositBits,
-    DivCeil, DivExact, DivFloor, FunnelShl, HighestOne, Ilog2, Isqrt, Midpoint, MultipleOf,
-    NextMultipleOf, NextPowerOfTwo, OverflowingSubUnsigned, Parity, SaturatingAbs, SaturatingCast,
-    ShlExact, StrictAdd, StrictEuclid, Truncate, UnboundedShr, UnsignedAbs, Widen, WideningMul,
-    WrappingPow,
+    AbsDiff, BitsPrecision, BorrowingSub, CarryingAdd, CarryingMul, CarrylessMul, CastSigned,
+    CastUnsigned, CheckedAddSigned, CheckedCast, CheckedPow, CheckedSignedDiff, ClampMagnitude,
+    DepositBits, DivCeil, DivExact, DivFloor, FunnelShl, HighestOne, Ilog2, Isqrt, Midpoint,
+    MultipleOf, NextMultipleOf, NextPowerOfTwo, OverflowingSubUnsigned, Parity, SaturatingAbs,
+    SaturatingCast, ShlExact, StrictAdd, StrictEuclid, Truncate, UnboundedShr, UnsignedAbs, Widen,
+    WideningMul, WrappingPow,
 };
 use const_num_traits::{
     Algebraic, FloatBits, FromAscii, FromByteSlice, FromBytes, Maximum, NextUp, ToBytes,
@@ -144,11 +144,13 @@ fn bits_in_const() {
     const EXSHL: Option<u8> = ShlExact::shl_exact(0x11u8, 3);
     const HI: Option<u32> = HighestOne::highest_one(0b0101_0000u8);
     const DEP: u8 = DepositBits::deposit_bits(0b101u8, 0b1111_0000);
+    const PREC: u32 = BitsPrecision::bits_precision(0u32);
     assert_eq!(USHR, -1);
     assert_eq!(FUN, 0x03);
     assert_eq!(EXSHL, Some(0x88));
     assert_eq!(HI, Some(6));
     assert_eq!(DEP, 0b0101_0000);
+    assert_eq!(PREC, 32);
 }
 
 #[test]

--- a/tests/const_nightly.rs
+++ b/tests/const_nightly.rs
@@ -14,7 +14,7 @@ use const_num_traits::{
     DepositBits, DivCeil, DivExact, DivFloor, FunnelShl, HighestOne, Ilog2, Isqrt, Midpoint,
     MultipleOf, NextMultipleOf, NextPowerOfTwo, OverflowingSubUnsigned, Parity, SaturatingAbs,
     SaturatingCast, ShlExact, StrictAdd, StrictEuclid, Truncate, UnboundedShr, UnsignedAbs, Widen,
-    WideningMul, WrappingPow,
+    WideningMul, WithPrecision, WrappingPow,
 };
 use const_num_traits::{
     Algebraic, FloatBits, FromAscii, FromByteSlice, FromBytes, Maximum, NextUp, ToBytes,
@@ -145,12 +145,17 @@ fn bits_in_const() {
     const HI: Option<u32> = HighestOne::highest_one(0b0101_0000u8);
     const DEP: u8 = DepositBits::deposit_bits(0b101u8, 0b1111_0000);
     const PREC: u32 = BitsPrecision::bits_precision(0u32);
+    // WithPrecision: identity on fixed-width carriers, const on nightly.
+    const WP: u32 = WithPrecision::widen_to_precision(5u32, 256);
+    const WPZ: u32 = <u32 as WithPrecision>::zero_with_precision(64);
+    const WPO: u32 = WithPrecision::one_with_precision_of(&7u32);
     assert_eq!(USHR, -1);
     assert_eq!(FUN, 0x03);
     assert_eq!(EXSHL, Some(0x88));
     assert_eq!(HI, Some(6));
     assert_eq!(DEP, 0b0101_0000);
     assert_eq!(PREC, 32);
+    assert_eq!((WP, WPZ, WPO), (5, 0, 1));
 }
 
 #[test]

--- a/tests/const_nightly.rs
+++ b/tests/const_nightly.rs
@@ -144,7 +144,7 @@ fn bits_in_const() {
     const EXSHL: Option<u8> = ShlExact::shl_exact(0x11u8, 3);
     const HI: Option<u32> = HighestOne::highest_one(0b0101_0000u8);
     const DEP: u8 = DepositBits::deposit_bits(0b101u8, 0b1111_0000);
-    const PREC: u32 = BitsPrecision::bits_precision(0u32);
+    const PREC: u32 = BitsPrecision::bits_precision(&0u32);
     // WithPrecision: identity on fixed-width carriers, const on nightly.
     const WP: u32 = WithPrecision::widen_to_precision(5u32, 256);
     const WPZ: u32 = <u32 as WithPrecision>::zero_with_precision(64);


### PR DESCRIPTION
Adds the `BitsPrecision { fn bits_precision(self) -> u32 }` trait — the cross-carrier **width** primitive.

## What

- **`BitsPrecision`** (`src/ops/bits.rs`): every carrier reports its operating **width** at runtime. A fixed carrier returns its type width (`u32` → 32, `FixedUInt<T,N>` → `N·word`); a variable-width bignum returns its constructed length (`len·word`). Impls for `u8`–`u128` + `usize`; `c0nst`-wrapped (const-callable on nightly, canary added).
- **Deliberately no `const BITS`.** A type-level width const only works for fixed carriers and is the exact shape that produced the `size_of*8` / `count_zeros(zero())` proxies this replaces. Width is a runtime `fn` for everyone; `core::u32::BITS` stays a primitive detail, not the width surface.
- Bit-length is unaffected — it already ships as `BitWidth::bit_width` (significant bits); consumers rebind the `bits_precision − leading_zeros` idiom onto it.

## Semver

Additive (new trait + impls); `0.2.0` → `0.2.1`. Verified: stable lib + doctests, nightly const canary, clippy (default + ct), fmt.

Downstream: modmath repoints `type_bit_width` → `operand.bits_precision()`; rsa repoints `bits_precision` → the trait fn and `bits()` → `BitWidth::bit_width()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `BitsPrecision` to retrieve a value/type’s fixed bit precision.
  * Added `WithPrecision` APIs for precision-aware zero/one creation and widening (including witness-based helpers).
  * Re-exported the new precision traits from the crate’s main interface.
* **Tests**
  * Expanded nightly const coverage to assert fixed precision at compile time.
  * Added unit tests covering widening/seed behavior for both fixed-width primitives and a runtime-width witness type.
* **Release**
  * Bumped the package version to `0.2.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->